### PR TITLE
Add Ecosystem section for skill discovery and creation tools

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -110,3 +110,24 @@ The Agent Skills format was originally developed by [Anthropic](https://www.anth
     Validate skills and generate prompt XML.
   </Card>
 </CardGroup>
+
+## Ecosystem
+
+Tools for discovering and creating Agent Skills.
+
+<CardGroup cols={2}>
+  <Card
+    title="SkillCreator"
+    icon="wand-magic-sparkles"
+    href="https://skillcreator.ai/discover"
+  >
+    Browse and install community-curated skills. Generate new skills from plain English.
+  </Card>
+  <Card
+    title="Contribute a tool"
+    icon="plus"
+    href="https://github.com/agentskills/agentskills/issues/new"
+  >
+    Building something for the Agent Skills ecosystem? Open an issue to get listed.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Adds a new "Ecosystem" section to the documentation homepage that provides a dedicated space for tools that help users discover and create Agent Skills.

**Changes:**
- Added SkillCreator card: Community-curated skill browser and plain English skill generator
- Added "Contribute a tool" card: Invitation for ecosystem builders to submit their tools

## Why this matters

The Agent Skills spec is great for defining *how* skills work, but users also need ways to *find* and *create* skills. This section creates a home for ecosystem tooling that complements the core specification.

The "Contribute a tool" card also opens the door for other builders in the space to get listed, making this a community-driven section rather than a one-off addition.

## Screenshot

The new section appears after "Get started" with two cards in a 2-column layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)