### PR TITLE
Add pi to adoption section

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -67,6 +67,10 @@ Agent Skills are supported by leading AI development tools.
     <img className="block dark:hidden object-contain" style={{width: '150px', maxWidth: '100%'}} src="/images/logos/oai-codex/OAI_Codex-Lockup_400px.svg" alt="OpenAI Codex" noZoom />
     <img className="hidden dark:block object-contain" style={{width: '150px', maxWidth: '100%'}} src="/images/logos/oai-codex/OAI_Codex-Lockup_400px_Darkmode.svg" alt="OpenAI Codex" noZoom />
   </a>
+  <a href="https://shittycodingagent.ai/" style={{textDecoration: 'none', border: 'none'}}>
+    <img className="block dark:hidden object-contain" style={{width: '80px', maxWidth: '100%'}} src="/images/logos/pi/pi-logo-light.svg" alt="pi" noZoom />
+    <img className="hidden dark:block object-contain" style={{width: '80px', maxWidth: '100%'}} src="/images/logos/pi/pi-logo-dark.svg" alt="pi" noZoom />
+  </a>
 </div>
 
 ## Open development

--- a/docs/images/logos/pi/pi-logo-dark.svg
+++ b/docs/images/logos/pi/pi-logo-dark.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <!-- i dot -->
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/docs/images/logos/pi/pi-logo-light.svg
+++ b/docs/images/logos/pi/pi-logo-light.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path fill="#191919" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <!-- i dot -->
+  <path fill="#191919" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>


### PR DESCRIPTION
Adds [pi](https://shittycodingagent.ai/) to the list of tools supporting Agent Skills.

pi is a terminal-based coding agent with multi-model support that implements the Agent Skills standard. See [documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md) for details on the implementation.

Rebased on current main per request in #17.