### PR TITLE
Add Windows installation instructions for skills-ref

### DIFF
--- a/skills-ref/README.md
+++ b/skills-ref/README.md
@@ -6,6 +6,8 @@ Reference library for Agent Skills.
 
 ## Installation
 
+### macOS / Linux
+
 Using pip:
 
 ```bash
@@ -21,7 +23,32 @@ uv sync
 source .venv/bin/activate
 ```
 
-After installation, the `skills-ref` executable will be available on your `$PATH` (within the activated virtual environment).
+### Windows
+
+Using pip (PowerShell):
+
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -e .
+```
+
+Using pip (Command Prompt):
+
+```cmd
+python -m venv .venv
+.venv\Scripts\activate.bat
+pip install -e .
+```
+
+Or using [uv](https://docs.astral.sh/uv/):
+
+```powershell
+uv sync
+.venv\Scripts\Activate.ps1
+```
+
+After installation, the `skills-ref` executable will be available on your `PATH` (within the activated virtual environment).
 
 ## Usage
 


### PR DESCRIPTION
Fixes #24

Adds Windows installation instructions for `skills-ref` and reorganizes with platform headers.

## Changes

- Added `### macOS / Linux` header for existing instructions
- Added `### Windows` section with:
  - PowerShell: `.venv\Scripts\Activate.ps1`
  - Command Prompt: `.venv\Scripts\activate.bat`
- Both pip and uv methods covered for each platform