### PR TITLE
Add coverage for SkillProperties.to_dict

### DIFF
--- a/skills-ref/tests/test_errors.py
+++ b/skills-ref/tests/test_errors.py
@@ -1,0 +1,84 @@
+"""Tests for errors module."""
+
+import pytest
+
+from skills_ref.errors import ParseError, SkillError, ValidationError
+
+
+class TestSkillError:
+    """Tests for SkillError base exception."""
+
+    def test_skill_error_is_exception(self):
+        """SkillError should be a subclass of Exception."""
+        assert issubclass(SkillError, Exception)
+
+    def test_skill_error_can_be_raised(self):
+        """SkillError should be raisable with a message."""
+        with pytest.raises(SkillError, match="test message"):
+            raise SkillError("test message")
+
+    def test_skill_error_message_accessible(self):
+        """SkillError message should be accessible via args."""
+        error = SkillError("my error message")
+        assert str(error) == "my error message"
+        assert error.args[0] == "my error message"
+
+
+class TestParseError:
+    """Tests for ParseError exception."""
+
+    def test_parse_error_inherits_skill_error(self):
+        """ParseError should be a subclass of SkillError."""
+        assert issubclass(ParseError, SkillError)
+
+    def test_parse_error_can_be_raised(self):
+        """ParseError should be raisable with a message."""
+        with pytest.raises(ParseError, match="invalid YAML"):
+            raise ParseError("invalid YAML")
+
+    def test_parse_error_caught_as_skill_error(self):
+        """ParseError should be catchable as SkillError."""
+        with pytest.raises(SkillError):
+            raise ParseError("parsing failed")
+
+
+class TestValidationError:
+    """Tests for ValidationError exception."""
+
+    def test_validation_error_inherits_skill_error(self):
+        """ValidationError should be a subclass of SkillError."""
+        assert issubclass(ValidationError, SkillError)
+
+    def test_validation_error_single_message(self):
+        """ValidationError with single message populates errors list."""
+        error = ValidationError("field is required")
+
+        assert str(error) == "field is required"
+        assert error.errors == ["field is required"]
+
+    def test_validation_error_with_errors_list(self):
+        """ValidationError can accept explicit errors list."""
+        errors_list = ["error 1", "error 2", "error 3"]
+        error = ValidationError("multiple errors", errors=errors_list)
+
+        assert str(error) == "multiple errors"
+        assert error.errors == errors_list
+        assert len(error.errors) == 3
+
+    def test_validation_error_errors_attribute_accessible(self):
+        """ValidationError.errors attribute should be accessible."""
+        error = ValidationError("test", errors=["a", "b"])
+
+        assert hasattr(error, "errors")
+        assert isinstance(error.errors, list)
+
+    def test_validation_error_empty_errors_list(self):
+        """ValidationError with empty errors list should work."""
+        error = ValidationError("no details", errors=[])
+
+        assert error.errors == []
+
+    def test_validation_error_caught_as_skill_error(self):
+        """ValidationError should be catchable as SkillError."""
+        with pytest.raises(SkillError):
+            raise ValidationError("validation failed")

--- a/skills-ref/tests/test_models.py
+++ b/skills-ref/tests/test_models.py
@@ -1,0 +1,33 @@
+"""Tests for the models module."""
+
+from skills_ref.models import SkillProperties
+
+
+def test_to_dict_omits_empty_optionals():
+    props = SkillProperties(name="demo", description="Demo skill")
+
+    result = props.to_dict()
+
+    assert result == {"name": "demo", "description": "Demo skill"}
+    assert "license" not in result
+    assert "compatibility" not in result
+    assert "allowed-tools" not in result
+    assert "metadata" not in result
+
+
+def test_to_dict_includes_optional_fields():
+    props = SkillProperties(
+        name="demo",
+        description="Demo skill",
+        license="MIT",
+        compatibility="Claude 3.5",
+        allowed_tools="Bash(*)",
+        metadata={"author": "tester"},
+    )
+
+    result = props.to_dict()
+
+    assert result["license"] == "MIT"
+    assert result["compatibility"] == "Claude 3.5"
+    assert result["allowed-tools"] == "Bash(*)"
+    assert result["metadata"] == {"author": "tester"}

--- a/skills-ref/tests/test_models.py
+++ b/skills-ref/tests/test_models.py
@@ -1,0 +1,165 @@
+"""Tests for models module."""
+
+from skills_ref.models import SkillProperties
+
+
+class TestToDict:
+    """Tests for SkillProperties.to_dict() method."""
+
+    def test_to_dict_omits_empty_optionals(self):
+        """Optional fields should be excluded when not set."""
+        props = SkillProperties(name="my-skill", description="A test skill")
+        result = props.to_dict()
+
+        assert result == {"name": "my-skill", "description": "A test skill"}
+        assert "license" not in result
+        assert "compatibility" not in result
+        assert "allowed-tools" not in result
+        assert "metadata" not in result
+
+    def test_to_dict_includes_optional_fields(self):
+        """Optional fields should be included when set."""
+        props = SkillProperties(
+            name="my-skill",
+            description="A test skill",
+            license="MIT",
+            compatibility="Python 3.11+",
+            allowed_tools="Bash(git:*)",
+            metadata={"author": "Test"},
+        )
+        result = props.to_dict()
+
+        assert result["name"] == "my-skill"
+        assert result["description"] == "A test skill"
+        assert result["license"] == "MIT"
+        assert result["compatibility"] == "Python 3.11+"
+        assert result["allowed-tools"] == "Bash(git:*)"
+        assert result["metadata"] == {"author": "Test"}
+
+    def test_to_dict_required_fields_always_present(self):
+        """Required fields (name, description) must always be in output."""
+        # With no optional fields
+        props_minimal = SkillProperties(name="minimal", description="Minimal skill")
+        result_minimal = props_minimal.to_dict()
+        assert "name" in result_minimal
+        assert "description" in result_minimal
+
+        # With all optional fields
+        props_full = SkillProperties(
+            name="full",
+            description="Full skill",
+            license="MIT",
+            compatibility="Any",
+            allowed_tools="Bash(*)",
+            metadata={"key": "value"},
+        )
+        result_full = props_full.to_dict()
+        assert "name" in result_full
+        assert "description" in result_full
+
+    def test_to_dict_hyphenated_allowed_tools_key(self):
+        """allowed_tools attribute maps to 'allowed-tools' key (snake_case to kebab-case)."""
+        props = SkillProperties(
+            name="tool-skill",
+            description="Has tools",
+            allowed_tools="Read Write Edit",
+        )
+        result = props.to_dict()
+
+        # Must use hyphenated key, not snake_case
+        assert "allowed-tools" in result
+        assert "allowed_tools" not in result
+        assert result["allowed-tools"] == "Read Write Edit"
+
+    def test_to_dict_empty_metadata_excluded(self):
+        """Empty metadata dict should be excluded from output."""
+        props = SkillProperties(
+            name="my-skill",
+            description="A test skill",
+            metadata={},
+        )
+        result = props.to_dict()
+
+        assert "metadata" not in result
+
+    def test_to_dict_metadata_with_multiple_entries(self):
+        """Metadata with multiple key-value pairs should be preserved."""
+        props = SkillProperties(
+            name="rich-skill",
+            description="Has rich metadata",
+            metadata={
+                "author": "Test Author",
+                "version": "1.0.0",
+                "homepage": "https://example.com",
+            },
+        )
+        result = props.to_dict()
+
+        assert result["metadata"] == {
+            "author": "Test Author",
+            "version": "1.0.0",
+            "homepage": "https://example.com",
+        }
+
+    def test_to_dict_unicode_values(self):
+        """Unicode characters in fields should be preserved."""
+        props = SkillProperties(
+            name="i18n-skill",
+            description="Supports 日本語, русский, and émojis 🎉",
+            metadata={"作者": "テスト"},
+        )
+        result = props.to_dict()
+
+        assert result["description"] == "Supports 日本語, русский, and émojis 🎉"
+        assert result["metadata"]["作者"] == "テスト"
+
+
+class TestSkillPropertiesDataclass:
+    """Tests for SkillProperties dataclass behavior."""
+
+    def test_default_metadata_is_empty_dict(self):
+        """Default metadata should be an empty dict, not None."""
+        props = SkillProperties(name="my-skill", description="A test skill")
+
+        assert props.metadata == {}
+        assert props.metadata is not None
+
+    def test_default_optional_fields_are_none(self):
+        """Optional string fields should default to None."""
+        props = SkillProperties(name="my-skill", description="A test skill")
+
+        assert props.license is None
+        assert props.compatibility is None
+        assert props.allowed_tools is None
+
+    def test_instances_have_independent_metadata(self):
+        """Each instance should have its own metadata dict (mutable default safety)."""
+        props1 = SkillProperties(name="skill-1", description="First")
+        props2 = SkillProperties(name="skill-2", description="Second")
+
+        props1.metadata["key"] = "value"
+
+        assert "key" not in props2.metadata
+        assert props1.metadata is not props2.metadata
+
+    def test_equality_with_same_values(self):
+        """Instances with identical values should be equal."""
+        props1 = SkillProperties(
+            name="my-skill",
+            description="A test skill",
+            license="MIT",
+        )
+        props2 = SkillProperties(
+            name="my-skill",
+            description="A test skill",
+            license="MIT",
+        )
+
+        assert props1 == props2
+
+    def test_inequality_with_different_values(self):
+        """Instances with different values should not be equal."""
+        props1 = SkillProperties(name="skill-a", description="First")
+        props2 = SkillProperties(name="skill-b", description="Second")
+
+        assert props1 != props2

--- a/skills-ref/tests/test_models.py
+++ b/skills-ref/tests/test_models.py
@@ -29,12 +29,14 @@ class TestToDict:
         )
         result = props.to_dict()
 
-        assert result["name"] == "my-skill"
-        assert result["description"] == "A test skill"
-        assert result["license"] == "MIT"
-        assert result["compatibility"] == "Python 3.11+"
-        assert result["allowed-tools"] == "Bash(git:*)"
-        assert result["metadata"] == {"author": "Test"}
+        assert result == {
+            "name": "my-skill",
+            "description": "A test skill",
+            "license": "MIT",
+            "compatibility": "Python 3.11+",
+            "allowed-tools": "Bash(git:*)",
+            "metadata": {"author": "Test"},
+        }
 
     def test_to_dict_required_fields_always_present(self):
         """Required fields (name, description) must always be in output."""
@@ -95,10 +97,14 @@ class TestToDict:
         )
         result = props.to_dict()
 
-        assert result["metadata"] == {
-            "author": "Test Author",
-            "version": "1.0.0",
-            "homepage": "https://example.com",
+        assert result == {
+            "name": "rich-skill",
+            "description": "Has rich metadata",
+            "metadata": {
+                "author": "Test Author",
+                "version": "1.0.0",
+                "homepage": "https://example.com",
+            },
         }
 
     def test_to_dict_unicode_values(self):


### PR DESCRIPTION
## What
- Add unit tests for SkillProperties.to_dict to ensure optional fields are omitted when empty and emitted correctly (including hyphenated allowed-tools and metadata).
- No runtime code changes.

## Why
- Strengthens regression coverage for the core model serialization shape.

## Testing
- cd skills-ref && . .venv/bin/activate && pytest -q (42 passed)
