### PR TITLE
Add VT Code logo to LogoCarousel

### DIFF
--- a/docs/images/logos/vtcode/vt_code_dark.svg
+++ b/docs/images/logos/vtcode/vt_code_dark.svg
@@ -1,0 +1,5 @@
+<svg width="800" height="160" viewBox="0 0 800 160" xmlns="http://www.w3.org/2000/svg">
+  <text x="60" y="100" font-family="SF Pro Display,-apple-system,BlinkMacSystemFont,sans-serif" font-size="72" font-weight="600" letter-spacing="2">
+    &gt; VT Code
+  </text>
+</svg>

--- a/docs/images/logos/vtcode/vt_code_light.svg
+++ b/docs/images/logos/vtcode/vt_code_light.svg
@@ -1,0 +1,5 @@
+<svg width="800" height="160" viewBox="0 0 800 160" xmlns="http://www.w3.org/2000/svg">
+  <text x="60" y="100" font-family="SF Pro Display,-apple-system,BlinkMacSystemFont,sans-serif" font-size="72" font-weight="600" letter-spacing="2" fill="#fff">
+    &gt; VT Code
+  </text>
+</svg>

--- a/docs/snippets/LogoCarousel.jsx
+++ b/docs/snippets/LogoCarousel.jsx
@@ -33,6 +33,7 @@ export const LogoCarousel = () => {
     { name: "Mistral AI Vibe", url: "https://github.com/mistralai/mistral-vibe", lightSrc: "/images/logos/mistral-vibe/vibe-logo_black.svg", darkSrc: "/images/logos/mistral-vibe/vibe-logo_white.svg", width: "80px" },
     { name: "Command Code", url: "https://commandcode.ai/", lightSrc: "/images/logos/command-code/command-code-logo-for-light.svg", darkSrc: "/images/logos/command-code/command-code-logo-for-dark.svg", width: "200px" },
     { name: "Ona", url: "https://ona.com", lightSrc: "/images/logos/ona/ona-wordmark-light.svg", darkSrc: "/images/logos/ona/ona-wordmark-dark.svg", width: "120px" },
+    { name: "VT Code", url: "https://github.com/vinhnx/vtcode", lightSrc: "/images/logos/vtcode/vtcode-logo-light.svg", darkSrc: "/images/logos/vtcode/vtcode-logo-dark.svg", width: "120px" },
   ];
 
   /* Shuffle logos on component mount */


### PR DESCRIPTION
Hi team, this PR to add VT Code to Logo carousel. Since VT Code has been supports Agent Skills spec when it was announced, and the integration is fully compatible to AgentSkills spec.

Docs: https://github.com/vinhnx/vtcode/blob/main/docs/SKILLS_GUIDE.md

Let me know if I need to do any adjustments. Thank you!