### PR TITLE
Fill in copyright holder in `LICENSE` appendix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Anthropic, PBC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace the placeholder `[yyyy] [name of copyright owner]` with `2025 Anthropic, PBC` to match the project's origin date and maintainer.

Closes #145