### PR TITLE
feat: add capabilities field to spec for security and transparency

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -38,6 +38,9 @@ With optional fields:
 name: pdf-processing
 description: Extract text and tables from PDF files, fill forms, merge documents.
 license: Apache-2.0
+capabilities:
+  - shell
+  - filesystem
 metadata:
   author: example-org
   version: "1.0"
@@ -50,6 +53,7 @@ metadata:
 | `description` | Yes | Max 1024 characters. Non-empty. Describes what the skill does and when to use it. |
 | `license` | No | License name or reference to a bundled license file. |
 | `compatibility` | No | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
+| `capabilities` | No | Array of capability strings declaring what system access the skill requires. See [capabilities field](#capabilities-field). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata. |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
 
@@ -129,6 +133,41 @@ compatibility: Requires git, docker, jq, and access to the internet
 
 <Note>
 Most skills do not need the `compatibility` field.
+</Note>
+
+#### `capabilities` field
+
+The optional `capabilities` field:
+- An array of strings declaring what system access the skill requires
+- Enables users, registries, scanners, and agent runtimes to understand and enforce what a skill can do
+- Skills without `capabilities` should be treated as having an unknown capability profile
+
+Recognized values:
+
+| Capability | What it covers |
+|------------|----------------|
+| `shell` | Execute shell commands, spawn processes |
+| `filesystem` | Write, edit, or delete files |
+| `network` | Make outbound HTTP requests, fetch URLs |
+| `browser` | Browser automation, screenshots, page interaction |
+
+Implementations may define additional capability values. Unknown values should produce a validation warning but not block parsing, for forward compatibility.
+
+Examples:
+```yaml
+capabilities:
+  - shell
+  - network
+```
+```yaml
+capabilities:
+  - filesystem
+```
+
+A skill that does not require any system access (e.g. a pure knowledge skill that only provides instructions) can omit the field entirely.
+
+<Note>
+The `capabilities` field is complementary to `allowed-tools`. While `allowed-tools` lists implementation-specific tool names a skill may invoke, `capabilities` declares abstract categories of system access the skill requires. `capabilities` is implementation-agnostic and designed for security visibility and enforcement across platforms.
 </Note>
 
 #### `metadata` field

--- a/skills-ref/src/skills_ref/models.py
+++ b/skills-ref/src/skills_ref/models.py
@@ -13,6 +13,7 @@ class SkillProperties:
         description: What the skill does and when the model should use it (required)
         license: License for the skill (optional)
         compatibility: Compatibility information for the skill (optional)
+        capabilities: System access capabilities the skill requires (optional)
         allowed_tools: Tool patterns the skill requires (optional, experimental)
         metadata: Key-value pairs for client-specific properties (defaults to
             empty dict; omitted from to_dict() output when empty)
@@ -22,6 +23,7 @@ class SkillProperties:
     description: str
     license: Optional[str] = None
     compatibility: Optional[str] = None
+    capabilities: Optional[list[str]] = None
     allowed_tools: Optional[str] = None
     metadata: dict[str, str] = field(default_factory=dict)
 
@@ -32,6 +34,8 @@ class SkillProperties:
             result["license"] = self.license
         if self.compatibility is not None:
             result["compatibility"] = self.compatibility
+        if self.capabilities is not None:
+            result["capabilities"] = self.capabilities
         if self.allowed_tools is not None:
             result["allowed-tools"] = self.allowed_tools
         if self.metadata:

--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -102,11 +102,17 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if not isinstance(description, str) or not description.strip():
         raise ValidationError("Field 'description' must be a non-empty string")
 
+    raw_capabilities = metadata.get("capabilities")
+    capabilities = None
+    if isinstance(raw_capabilities, list):
+        capabilities = [str(c) for c in raw_capabilities if c]
+
     return SkillProperties(
         name=name.strip(),
         description=description.strip(),
         license=metadata.get("license"),
         compatibility=metadata.get("compatibility"),
+        capabilities=capabilities,
         allowed_tools=metadata.get("allowed-tools"),
         metadata=metadata.get("metadata"),
     )

--- a/skills-ref/tests/test_parser.py
+++ b/skills-ref/tests/test_parser.py
@@ -186,3 +186,38 @@ Body
     # Verify to_dict outputs as "allowed-tools" (hyphenated)
     d = props.to_dict()
     assert d["allowed-tools"] == "Bash(jq:*) Bash(git:*)"
+
+
+def test_read_with_capabilities(tmp_path):
+    """capabilities should be parsed into SkillProperties."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities:
+  - shell
+  - network
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.capabilities == ["shell", "network"]
+    d = props.to_dict()
+    assert d["capabilities"] == ["shell", "network"]
+
+
+def test_read_without_capabilities(tmp_path):
+    """Missing capabilities should result in None."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.capabilities is None
+    d = props.to_dict()
+    assert "capabilities" not in d

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -288,3 +288,88 @@ Body
 """)
     errors = validate(skill_dir)
     assert errors == [], f"Expected no errors, got: {errors}"
+
+
+def test_valid_capabilities(tmp_path):
+    """Valid capabilities should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities:
+  - shell
+  - filesystem
+  - network
+  - browser
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_unrecognized_capability_warns(tmp_path):
+    """Unrecognized capabilities should produce a warning but not block."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities:
+  - shell
+  - telekinesis
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert any("Unrecognized capability" in e and "telekinesis" in e for e in errors)
+
+
+def test_duplicate_capability(tmp_path):
+    """Duplicate capabilities should produce an error."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities:
+  - shell
+  - shell
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert any("Duplicate capability" in e and "shell" in e for e in errors)
+
+
+def test_empty_capabilities_list(tmp_path):
+    """Empty capabilities list should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities: []
+---
+Body
+""")
+    errors = validate(skill_dir)
+    # strictyaml may parse empty list differently, but no crash
+    assert not any("capabilities" in e.lower() for e in errors) or errors == []
+
+
+def test_single_capability(tmp_path):
+    """A single capability should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+capabilities:
+  - network
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []


### PR DESCRIPTION
This PR implements the proposal from #170.

## Problem

Skills are a new class of executable content. When an agent loads a SKILL.md, those instructions can trigger arbitrary tool calls - shell commands, file writes, network requests, browser automation. But the spec has no structured way for a skill to declare what system access it needs, and no way for users or platforms to know what a skill can do before it runs.

This is already being exploited. Snyk's ToxicSkills research found that **13.4% of all skills contain at least one critical-level security issue**, with 76 confirmed malicious payloads and 1,467 skills (36.8%) having at least one security flaw. 100% of confirmed malicious skills contain malicious code patterns, and 91% simultaneously employ prompt injection.

The ecosystem is already bolting on external scanning solutions [ClawHub.ai / OpenClaw](https://openclaw.ai/blog/virustotal-partnership), ([skills.sh/Vercel](https://vercel.com/changelog/automated-security-audits-now-available-for-skills-sh), [skillaudit.sh](https://skillaudit.sh/checks), [Cisco skill-scanner](https://github.com/cisco-ai-defense/skill-scanner), [Snyk ToxicSkills](https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/)) but without structured capability declarations in the spec itself, scanners can't distinguish intentional tool usage from capability abuse, users have no signal before install, and runtime enforcement has nothing to enforce against.

Skills represent a completely new file type class for execution, and like mobile apps and browser extensions before them, they need transparency and security embedded into their core format - not bolted on by third parties after the damage is done.

## What this PR adds

A `capabilities` field in the SKILL.md frontmatter:

```yaml
---
name: git-autopush
description: Automate git commit, push, and PR workflows.
capabilities:
  - shell
  - network
---
```

### Recognized capabilities

| Capability | What it covers |
|------------|----------------|
| `shell` | Execute shell commands, spawn processes |
| `filesystem` | Write, edit, or delete files |
| `network` | Make outbound HTTP requests, fetch URLs |
| `browser` | Browser automation, screenshots, page interaction |

Implementations may extend this list. Unknown values produce a validation warning but don't block parsing, for forward compatibility.

### Why this belongs in the spec, not in external scanners

The scanning tools are doing important work, but they're pattern-matching against skills that never declared their intent. A "summarize text" skill that calls `curl` is suspicious - but only if you know it never declared `network`. Capabilities give every layer of the ecosystem - authors, users, scanners, registries, and agent runtimes - a shared contract to work with.

### The bait-and-switch problem

Static scanning - no matter how sophisticated - only evaluates a skill at a point in time. Skills that declare `network` or `shell` can fetch remote content that changes after review. A skill passes every scanner on day one. On day five, the remote endpoint it calls starts serving malicious payloads. The SKILL.md hasn't changed, the scan results are still "clean", but the skill is now exfiltrating credentials.

Capability declarations don't solve this entirely, but they give platforms a critical tool: a skill that only declares `filesystem` literally cannot fetch remote content if the runtime enforces capabilities. The attack surface is bounded by what the skill declared, not by what the scanner happened to catch on the day it ran. This is the difference between "we scanned it and it looked fine" and "it structurally cannot do this."

### Relationship to existing fields

- **`allowed-tools`** is implementation-specific (tool names vary across agents) and permissive (pre-approves tools). `capabilities` is implementation-agnostic (abstract categories) and declarative (states what the skill needs, enforcement is up to the platform). They're complementary.
- **`compatibility`** is free text for environment requirements. `capabilities` is structured metadata for system access declarations. A skill might have both.

### Prior art

- **iOS/macOS entitlements** - apps declare capabilities, users see them before install, the OS enforces at runtime
- **Android permissions** - declared in manifest, shown to users, enforced by the framework
- **Browser extension permissions** - extensions declare what APIs they need, users approve at install time
- **OpenClaw/ClawHub** - we're in the process of implementing this in production to enforce capability checks at runtime (blocking undeclared tool calls for community skills), ClawHub surfaces them in the UI with capability badges and a "No capabilities declared" flag. PRs: [openclaw/openclaw#18196](https://github.com/openclaw/openclaw/pull/18196), [openclaw/clawhub#358](https://github.com/openclaw/clawhub/pull/358)

## Changes

- **`docs/specification.mdx`** - `capabilities` field added to frontmatter spec with recognized values table, usage examples, and relationship to `allowed-tools`/`compatibility`
- **`skills-ref/src/skills_ref/models.py`** - `capabilities` field on `SkillProperties` dataclass + `to_dict()` support
- **`skills-ref/src/skills_ref/parser.py`** - parse `capabilities` from frontmatter as list of strings
- **`skills-ref/src/skills_ref/validator.py`** - validate capabilities (type check, recognized values warning, duplicate detection)
- **`skills-ref/tests/test_parser.py`** - parsing tests for capabilities present/absent
- **`skills-ref/tests/test_validator.py`** - validation tests for valid, unrecognized, duplicate, single, and empty capabilities
