### PR TITLE
feat: add credentials field to spec for declaring skill secrets

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -38,6 +38,10 @@ With optional fields:
 name: pdf-processing
 description: Extract text and tables from PDF files, fill forms, merge documents.
 license: Apache-2.0
+credentials:
+  - name: OPENAI_API_KEY
+    description: OpenAI API key for OCR-assisted extraction
+    required: false
 metadata:
   author: example-org
   version: "1.0"
@@ -51,6 +55,7 @@ metadata:
 | `license` | No | License name or reference to a bundled license file. |
 | `compatibility` | No | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata. |
+| `credentials` | No | List of credentials the skill requires. Each entry has `name`, `description`, and optional `required` (defaults to `true`). |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
 
 #### `name` field
@@ -144,6 +149,35 @@ metadata:
   author: example-org
   version: "1.0"
 ```
+
+#### `credentials` field
+
+The optional `credentials` field:
+- A list of credentials the skill needs to function
+- Each entry is a mapping with the following properties:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Environment-variable-style identifier for the credential (e.g. `OPENAI_API_KEY`, `GITHUB_TOKEN`). Uppercase letters, digits, and underscores only. Must start with a letter. |
+| `description` | Yes | What the credential is for, including any scope or permission requirements. |
+| `required` | No | Whether the skill requires this credential to function. Defaults to `true`. |
+
+Credential names follow the environment variable convention that developers and SDKs already use (e.g. `OPENAI_API_KEY`, `STRIPE_SECRET_KEY`). This makes it natural for runtimes to resolve credentials from environment variables, vaults, or other secret stores without a translation layer.
+
+Example with multiple credentials:
+```yaml
+credentials:
+  - name: TRELLO_API_KEY
+    description: Trello API key for board access
+  - name: TRELLO_TOKEN
+    description: Trello member token with read/write scope
+  - name: SLACK_WEBHOOK_URL
+    description: Slack incoming webhook URL for posting notifications
+    required: false
+```
+
+The `credentials` field is declarative — it states what a skill needs, not how to provision it. Agent implementations and secret management systems (vaults, environment injection, etc.) decide how credentials are resolved and injected at runtime.
+
 
 #### `allowed-tools` field
 

--- a/skills-ref/src/skills_ref/models.py
+++ b/skills-ref/src/skills_ref/models.py
@@ -5,6 +5,28 @@ from typing import Optional
 
 
 @dataclass
+class Credential:
+    """A credential declared by a skill.
+
+    Attributes:
+        name: Environment-variable-style identifier (e.g. OPENAI_API_KEY)
+        description: What the credential is for
+        required: Whether the skill requires this credential (defaults to True)
+    """
+
+    name: str
+    description: str
+    required: bool = True
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        result = {"name": self.name, "description": self.description}
+        if not self.required:
+            result["required"] = False
+        return result
+
+
+@dataclass
 class SkillProperties:
     """Properties parsed from a skill's SKILL.md frontmatter.
 
@@ -13,6 +35,7 @@ class SkillProperties:
         description: What the skill does and when the model should use it (required)
         license: License for the skill (optional)
         compatibility: Compatibility information for the skill (optional)
+        credentials: List of credentials the skill requires (optional)
         allowed_tools: Tool patterns the skill requires (optional, experimental)
         metadata: Key-value pairs for client-specific properties (defaults to
             empty dict; omitted from to_dict() output when empty)
@@ -22,6 +45,7 @@ class SkillProperties:
     description: str
     license: Optional[str] = None
     compatibility: Optional[str] = None
+    credentials: Optional[list[Credential]] = None
     allowed_tools: Optional[str] = None
     metadata: dict[str, str] = field(default_factory=dict)
 
@@ -32,6 +56,8 @@ class SkillProperties:
             result["license"] = self.license
         if self.compatibility is not None:
             result["compatibility"] = self.compatibility
+        if self.credentials is not None:
+            result["credentials"] = [c.to_dict() for c in self.credentials]
         if self.allowed_tools is not None:
             result["allowed-tools"] = self.allowed_tools
         if self.metadata:


### PR DESCRIPTION
## Summary

This PR adds an optional `credentials` field to the SKILL.md frontmatter, allowing skills to declare what API keys, tokens, or other secrets they need to function.

Discussion: https://github.com/agentskills/agentskills/discussions/173

### Problem

Skills that interact with external services (OpenAI, GitHub, Trello, Slack, etc.) need API credentials, but the spec has no structured way for a skill to declare those dependencies. Today, users discover credential requirements only by reading skill instructions or hitting runtime errors. This creates friction for both skill authors and the platforms that provision secrets.

Projects like [moldable-skills](https://github.com/moldable-ai/moldable-skills) have started addressing this with ad-hoc `dependencies.secrets` fields, but the approach is tightly coupled to environment variable naming and lacks metadata like descriptions or required/optional distinctions.

### Vault Support

Projects like [aivault](https://github.com/moldable-ai/aivault) plan to use these keys as a way to ensure all skills have proper secret management as more and more agents operate in local environments with privileged access.

### What this PR adds

A `credentials` field in the SKILL.md frontmatter:

```yaml
---
name: image-generator
description: Generate images using OpenAI Image Gen
credentials:
  - name: OPENAI_API_KEY
    description: OpenAI API key for image generation
  - name: SLACK_WEBHOOK_URL
    description: Slack webhook for posting generated images
    required: false
---
```

#### Credential entry properties

| Property | Required | Description |
|----------|----------|-------------|
| `name` | Yes | Environment-variable-style identifier (e.g. `OPENAI_API_KEY`, `GITHUB_TOKEN`). Uppercase letters, digits, and underscores only. Must start with a letter. |
| `description` | Yes | What the credential is for, including any scope or permission requirements. |
| `required` | No | Whether the skill requires this credential to function. Defaults to `true`. |

#### Why `credentials` over `env`

We considered `env` since the names follow environment variable conventions, but `env` implies general configuration (e.g. `NODE_ENV`, `DEBUG`, `PORT`). `credentials` is specific to authentication secrets, which signals to runtimes and vaults that these values are sensitive and should be handled accordingly — not just passed through as plain config.

#### Why SCREAMING_SNAKE_CASE names

Credential names use the environment variable convention that developers and SDKs already use (`OPENAI_API_KEY`, `STRIPE_SECRET_KEY`, `GITHUB_TOKEN`). This makes it natural for runtimes to resolve credentials from environment variables, vaults, or other secret stores without a translation layer. Every SDK README already tells you to "set `OPENAI_API_KEY`" — the spec should speak the same language.

#### Design principles

- **Declarative**: States what a skill needs, not how to provision it. Runtimes (environment variables, vaults like [aivault](https://github.com/moldable-ai/aivault), platform-managed secrets) decide how credentials are resolved and injected.
- **Structured**: Unlike a bare list of env var names, each credential carries a description (what it's for, what scopes/permissions are needed) and a required/optional flag.
- **Implementation-agnostic**: Works with any secret management approach — env vars, encrypted vaults, platform-managed credential stores, or interactive prompts.

#### Relationship to existing fields

- **`compatibility`** covers environment requirements (system packages, network access). `credentials` specifically covers authentication secrets needed for external service access.
- **`allowed-tools`** pre-approves agent tools. `credentials` declares external service dependencies. They are complementary.

## Example Implementation from [Moldable](https://moldable.sh)

<img width="1354" height="1760" alt="CleanShot 2026-02-18 at 14 47 23@2x" src="https://github.com/user-attachments/assets/400cfa2c-a9c3-4596-a089-6c68860b31d2" />

## Test plan

- [x] Parser tests: credentials parsed correctly, round-trips through `to_dict()`, absent credentials yield `None`
- [x] Validator tests: valid credentials accepted, invalid name format rejected, missing name/description caught, duplicate names caught, unexpected entry fields caught, single credential accepted
- [x] All 49 tests pass
- [x] Ruff lint and format checks pass