### PR TITLE
Add skill folder standard in the spec

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -7,7 +7,7 @@ This document defines the Agent Skills format.
 
 ## Skills location
 
-It's recommended that adopters of the standard allow automatically load skills 
+It's recommended that adopters of the standard automatically load skills 
 from `~/.agents/skills` (user scope) and/or `.agents/skills` (project scope). 
 An alternative could be to allow the users to configure where they want to load
 skills from.

--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -5,6 +5,13 @@ description: "The complete format specification for Agent Skills."
 
 This document defines the Agent Skills format.
 
+## Skills location
+
+It's recommended that adopters of the standard allow automatically load skills 
+from `~/.agents/skills` (user scope) and/or `.agents/skills` (project scope). 
+An alternative could be to allow the users to configure where they want to load
+skills from.
+
 ## Directory structure
 
 A skill is a directory containing at minimum a `SKILL.md` file:


### PR DESCRIPTION
This PR adds the proposal from #15 into the specification. This has been already implemented by many vendors (see the list in the issue, it grows almost on a weekly basis) and became the de-facto vendor-neutral standard.

I put it as "recommended" because I think this is what makes more sense. But if maintainers decide we should change the wording there or make it mandatory, I'm fine with it.

I also didn't have a veeeery good idea of where to put this information, so I went for the simplest thing possible. Also open to feedback and more guidance on where we could have this written.

