### PR TITLE
Document no-checkout skills-ref usage with `uvx` and `pipx`

### DIFF
--- a/docs/integrate-skills.mdx
+++ b/docs/integrate-skills.mdx
@@ -90,10 +90,20 @@ For example:
 ```
 skills-ref validate <path>
 ```
+Or without installation:
+```
+uvx --from skills-ref agentskills validate <path>
+pipx run skills-ref validate <path>
+```
 
 **Generate `<available_skills>` XML for agent prompts:**
 ```
 skills-ref to-prompt <path>...
+```
+Or without installation:
+```
+uvx --from skills-ref agentskills to-prompt <path>...
+pipx run skills-ref to-prompt <path>...
 ```
 
 Use the library source code as a reference implementation.

--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -225,4 +225,11 @@ Use the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills
 skills-ref validate ./my-skill
 ```
 
+Or run it without installation:
+
+```bash
+uvx --from skills-ref agentskills validate ./my-skill
+pipx run skills-ref validate ./my-skill
+```
+
 This checks that your `SKILL.md` frontmatter is valid and follows all naming conventions.

--- a/skills-ref/README.md
+++ b/skills-ref/README.md
@@ -51,6 +51,27 @@ uv sync
 
 After installation, the `skills-ref` executable will be available on your `PATH` (within the activated virtual environment).
 
+### Run without local installation
+
+Using [uvx](https://docs.astral.sh/uv/guides/tools/):
+
+```bash
+uvx --from skills-ref agentskills validate path/to/skill
+```
+
+Using [pipx](https://pipx.pypa.io/) (single-line):
+
+```bash
+pipx run skills-ref validate path/to/skill
+```
+
+Install with `pipx` for repeated usage:
+
+```bash
+pipx install skills-ref
+agentskills validate path/to/skill
+```
+
 ## Usage
 
 ### CLI
@@ -64,6 +85,13 @@ skills-ref read-properties path/to/skill
 
 # Generate <available_skills> XML for agent prompts
 skills-ref to-prompt path/to/skill-a path/to/skill-b
+```
+
+`uvx`/`pipx run` can execute any command above without cloning this repository:
+
+```bash
+uvx --from skills-ref agentskills to-prompt path/to/skill-a path/to/skill-b
+pipx run skills-ref to-prompt path/to/skill-a path/to/skill-b
 ```
 
 ### Python API


### PR DESCRIPTION
Add package-index command examples for running `skills-ref` without
cloning this repository.

This updates docs to show no-checkout usage via:
- `uvx --from skills-ref agentskills ...`
- `pipx run skills-ref ...` (single-line)

Updated files:
- `skills-ref/README.md`
- `docs/specification.mdx`
- `docs/integrate-skills.mdx`

Also clarifies that package-based invocation uses the `agentskills`
entrypoint for `uvx` and `pipx install`.

Verification:
- `uvx --from skills-ref agentskills validate --help`
- `uvx --from skills-ref agentskills to-prompt --help`
- `pipx run skills-ref validate --help`
- `pipx run skills-ref to-prompt --help`

AI disclosure: This PR was authored with Codex assistance AND I understand and validated the changes that were made!
