### PR TITLE
📝 Add library skills

### DIFF
--- a/docs/integrate-skills.mdx
+++ b/docs/integrate-skills.mdx
@@ -28,6 +28,24 @@ A skills-compatible agent needs to:
 
 Skills are folders containing a `SKILL.md` file. Your agent should scan configured directories for valid skills.
 
+### Library skills
+
+Agents working on a programming environment such as Python or JavaScript (TypeScript) with access to installed libraries can scan those libraries to find skills to work with them, defined by them.
+
+Each library can define their own skills in a `.agents/skills/` directory inside of their own package.
+
+For example, a Python library like `fastapi` could include a skill at `fastapi/.agents/skills/fastapi/SKILL.md`.
+
+If the Python virtual environment being used is at `.venv`, the agent could find that skill in a directory like `.venv/lib64/python3.14/site-packages/fastapi/.agents/skills/fastapi/SKILL.md` (in this case using Python 3.14 and a 64-bit environment).
+
+A JavaScript library like `@tanstack/react-router` could include a skill at `@tanstack/react-router/.agents/skills/tanstack-router/SKILL.md`.
+
+The agent could find that skill in a directory like `node_modules/@tanstack/react-router/.agents/skills/tanstack-router/SKILL.md`.
+
+Libraries can provide their official skills instructing how to work with them this way. They can define multiple skills if needed.
+
+By using library skills, agents can make sure they follow the best practices defined by those libraries, up to date with their latest versions.
+
 ## Loading metadata
 
 At startup, parse only the frontmatter of each `SKILL.md` file. This keeps initial context usage low.


### PR DESCRIPTION
## Description

I would like for there to be a predefined standard / convention for libraries to define their own skills.

I think the main thing we would need is to agree on the directory structure.

## Support

If this is accepted, I'll add official skills to my Python libraries: FastAPI, SQLModel, Typer, Asyncer (and others).

I know the JS ecosystem also wants this, in fact, I copied this idea from @yyx990803 (https://x.com/youyuxi/status/2024595629134270918) (Vue.js, Vite, etc).

I know @tannerlinsley was also interested (TanStack projects).

I suspect that if some packages in both ecosystems (Python, JS/TS) adopt this, that would encourage agent providers to adopt it.

## Bikeshedding

I suggest this directory `.agents/skills` based on this conversation https://github.com/agentskills/agentskills/issues/27 leading to this tweet: https://x.com/iannuttall/status/2018760297368932726

Although that refers to a local code directory, not a library directory. But as library directories are normally not at the top level of a project, I suspect it would be fine to have the same name.

Alternatives I thought of:

- `.skills/`
- `.ai/skills/`
- `skills/`

Other names might work too, I don't have a strong preference. But we should agree on a naming convention.