### PR TITLE
Update README with correct install command for using uv on Mac

### DIFF
--- a/skills-ref/README.md
+++ b/skills-ref/README.md
@@ -21,7 +21,7 @@ Or using [uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv sync
-source .venv/bin/activate
+uv pip install -e .
 ```
 
 ### Windows


### PR DESCRIPTION
For using uv on Mac. 
activate the venv does not install the package. change it to `uv pip install -e .`