### PR TITLE
Fix example description to include "when to use" guidance

### DIFF
--- a/docs/client-implementation/adding-skills-support.mdx
+++ b/docs/client-implementation/adding-skills-support.mdx
@@ -168,7 +168,7 @@ For each discovered skill, include `name`, `description`, and optionally `locati
 <available_skills>
   <skill>
     <name>pdf-processing</name>
-    <description>Extract text and tables from PDF files, fill forms, merge documents.</description>
+    <description>Extract PDF text, fill forms, merge files. Use when handling PDFs.</description>
     <location>/home/user/.agents/skills/pdf-processing/SKILL.md</location>
   </skill>
   <skill>

--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -36,7 +36,7 @@ With optional fields:
 ```yaml
 ---
 name: pdf-processing
-description: Extract text and tables from PDF files, fill forms, merge documents.
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
 license: Apache-2.0
 metadata:
   author: example-org

--- a/docs/what-are-skills.mdx
+++ b/docs/what-are-skills.mdx
@@ -32,7 +32,7 @@ Every skill starts with a `SKILL.md` file containing YAML frontmatter and Markdo
 ```mdx
 ---
 name: pdf-processing
-description: Extract text and tables from PDF files, fill forms, merge documents.
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
 ---
 
 # PDF Processing


### PR DESCRIPTION
The example `description` values in what-are-skills.mdx and specification.mdx only described what the skill does, but omitted when to use it. This contradicted the spec's own guidance that description should cover both. Added a "Use when..." clause while keeping the line short enough to avoid clipping in the rendered code block on the docs site.