### PR TITLE
feat: add feature flags for context-aware skill loading

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -29,6 +29,7 @@ The `SKILL.md` file must contain YAML frontmatter followed by Markdown content.
 | `license` | No | License name or reference to a bundled license file. |
 | `compatibility` | No | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata. |
+| `features` | No | Feature flags for context-aware loading. See [Feature flags](#feature-flags). |
 | `allowed-tools` | No | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
 
 <Card>
@@ -169,6 +170,82 @@ The optional `allowed-tools` field:
 allowed-tools: Bash(git:*) Bash(jq:*) Read
 ```
 </Card>
+
+#### `features` field
+
+The optional `features` field enables context-aware skill loading by declaring sub-capabilities within a skill. Consumers can activate only the relevant subset, reducing context window cost while maintaining a single source of truth.
+
+The `features` field is a mapping with the following sub-fields:
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `default` | Yes (if `features` present) | List of feature names activated when none are explicitly selected |
+| `available` | Yes (if `features` present) | Map of feature name to feature definition |
+| `conflicts` | No | List of mutually exclusive feature sets |
+
+Each feature definition in `available` has:
+
+| Sub-field | Required | Description |
+|-----------|----------|-------------|
+| `description` | Yes | Human-readable description of the feature |
+| `section` | Yes | Markdown heading that starts this feature's content (e.g., `"## App Router"`) |
+| `requires` | No | List of other feature names that must also be activated |
+
+<Card>
+**Example with feature flags:**
+
+```markdown SKILL.md
+---
+name: pdf-processing
+description: Extract PDF text, fill forms, merge files. Use when handling PDFs.
+features:
+  default:
+    - extraction
+    - forms
+  available:
+    extraction:
+      description: Extract text and tables from PDF files
+      section: "## Extraction"
+    forms:
+      description: Fill and flatten PDF form fields
+      section: "## Forms"
+    merging:
+      description: Combine multiple PDFs into one
+      section: "## Merging"
+    ocr:
+      description: OCR scanned PDFs into searchable text
+      section: "## OCR"
+      requires:
+        - extraction
+---
+
+# PDF Processing
+
+General setup and configuration...
+
+## Extraction
+<!-- feature: extraction -->
+Text and table extraction instructions...
+
+## Forms
+<!-- feature: forms -->
+Form filling instructions...
+
+## Merging
+<!-- feature: merging -->
+PDF merging instructions...
+
+## OCR
+<!-- feature: ocr -->
+OCR processing instructions...
+```
+</Card>
+
+**Content demarcation:** Each feature maps to a heading-delimited section in the body. Content before any feature section is always included (preamble). An optional HTML comment (`<!-- feature: name -->`) can make boundaries explicit.
+
+**Feature resolution:** When activating features, consumers should: (1) start with explicitly selected features or `default`, (2) recursively add `requires` dependencies, (3) check for `conflicts` violations, (4) extract corresponding sections plus preamble.
+
+**Backward compatibility:** Skills without `features` work exactly as before. Agents that don't understand feature flags load the full SKILL.md as-is — the HTML comments are invisible in markdown rendering.
 
 ### Body content
 

--- a/skills-ref/src/skills_ref/__init__.py
+++ b/skills-ref/src/skills_ref/__init__.py
@@ -1,7 +1,7 @@
 """Reference library for Agent Skills."""
 
 from .errors import ParseError, SkillError, ValidationError
-from .models import SkillProperties
+from .models import FeatureDefinition, Features, SkillProperties
 from .parser import find_skill_md, read_properties
 from .prompt import to_prompt
 from .validator import validate
@@ -10,6 +10,8 @@ __all__ = [
     "SkillError",
     "ParseError",
     "ValidationError",
+    "FeatureDefinition",
+    "Features",
     "SkillProperties",
     "find_skill_md",
     "validate",

--- a/skills-ref/src/skills_ref/models.py
+++ b/skills-ref/src/skills_ref/models.py
@@ -5,6 +5,53 @@ from typing import Optional
 
 
 @dataclass
+class FeatureDefinition:
+    """A single feature within a skill.
+
+    Attributes:
+        description: Human-readable description of what this feature provides
+        section: Markdown heading that starts this feature's content (e.g., "## App Router")
+        requires: Other features that must also be activated when this one is active
+    """
+
+    description: str
+    section: str
+    requires: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary, excluding empty requires."""
+        result = {"description": self.description, "section": self.section}
+        if self.requires:
+            result["requires"] = self.requires
+        return result
+
+
+@dataclass
+class Features:
+    """Feature flags for context-aware skill loading.
+
+    Attributes:
+        default: Features activated when none are explicitly selected
+        available: Map of feature name to feature definition
+        conflicts: Sets of mutually exclusive features
+    """
+
+    default: list[str]
+    available: dict[str, FeatureDefinition]
+    conflicts: list[list[str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary, excluding empty conflicts."""
+        result = {
+            "default": self.default,
+            "available": {k: v.to_dict() for k, v in self.available.items()},
+        }
+        if self.conflicts:
+            result["conflicts"] = self.conflicts
+        return result
+
+
+@dataclass
 class SkillProperties:
     """Properties parsed from a skill's SKILL.md frontmatter.
 
@@ -14,6 +61,7 @@ class SkillProperties:
         license: License for the skill (optional)
         compatibility: Compatibility information for the skill (optional)
         allowed_tools: Tool patterns the skill requires (optional, experimental)
+        features: Feature flags for context-aware loading (optional)
         metadata: Key-value pairs for client-specific properties (defaults to
             empty dict; omitted from to_dict() output when empty)
     """
@@ -23,6 +71,7 @@ class SkillProperties:
     license: Optional[str] = None
     compatibility: Optional[str] = None
     allowed_tools: Optional[str] = None
+    features: Optional[Features] = None
     metadata: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -34,6 +83,8 @@ class SkillProperties:
             result["compatibility"] = self.compatibility
         if self.allowed_tools is not None:
             result["allowed-tools"] = self.allowed_tools
+        if self.features is not None:
+            result["features"] = self.features.to_dict()
         if self.metadata:
             result["metadata"] = self.metadata
         return result

--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -6,7 +6,7 @@ from typing import Optional
 import strictyaml
 
 from .errors import ParseError, ValidationError
-from .models import SkillProperties
+from .models import FeatureDefinition, Features, SkillProperties
 
 
 def find_skill_md(skill_dir: Path) -> Optional[Path]:
@@ -102,11 +102,78 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if not isinstance(description, str) or not description.strip():
         raise ValidationError("Field 'description' must be a non-empty string")
 
+    features = None
+    if "features" in metadata:
+        features = _parse_features(metadata["features"])
+
     return SkillProperties(
         name=name.strip(),
         description=description.strip(),
         license=metadata.get("license"),
         compatibility=metadata.get("compatibility"),
         allowed_tools=metadata.get("allowed-tools"),
+        features=features,
         metadata=metadata.get("metadata"),
     )
+
+
+def _parse_features(raw: dict) -> Features:
+    """Parse features field from frontmatter into Features model.
+
+    Args:
+        raw: Raw features dict from YAML parsing
+
+    Returns:
+        Features dataclass
+
+    Raises:
+        ValidationError: If features structure is invalid
+    """
+    if not isinstance(raw, dict):
+        raise ValidationError("Field 'features' must be a mapping")
+
+    if "default" not in raw:
+        raise ValidationError("Field 'features.default' is required")
+    if "available" not in raw:
+        raise ValidationError("Field 'features.available' is required")
+
+    default = raw["default"]
+    if isinstance(default, str):
+        default = [default]
+    if not isinstance(default, list):
+        raise ValidationError("Field 'features.default' must be a list")
+
+    available_raw = raw["available"]
+    if not isinstance(available_raw, dict):
+        raise ValidationError("Field 'features.available' must be a mapping")
+
+    available = {}
+    for feat_name, feat_def in available_raw.items():
+        if not isinstance(feat_def, dict):
+            raise ValidationError(
+                f"Feature '{feat_name}' definition must be a mapping"
+            )
+        if "description" not in feat_def:
+            raise ValidationError(
+                f"Feature '{feat_name}' is missing required field 'description'"
+            )
+        if "section" not in feat_def:
+            raise ValidationError(
+                f"Feature '{feat_name}' is missing required field 'section'"
+            )
+
+        requires = feat_def.get("requires", [])
+        if isinstance(requires, str):
+            requires = [requires]
+
+        available[feat_name] = FeatureDefinition(
+            description=feat_def["description"],
+            section=feat_def["section"],
+            requires=requires,
+        )
+
+    conflicts = raw.get("conflicts", [])
+    if not isinstance(conflicts, list):
+        raise ValidationError("Field 'features.conflicts' must be a list")
+
+    return Features(default=default, available=available, conflicts=conflicts)

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -19,6 +19,7 @@ ALLOWED_FIELDS = {
     "allowed-tools",
     "metadata",
     "compatibility",
+    "features",
 }
 
 
@@ -143,6 +144,76 @@ def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[
 
     if "compatibility" in metadata:
         errors.extend(_validate_compatibility(metadata["compatibility"]))
+
+    if "features" in metadata:
+        errors.extend(_validate_features(metadata["features"]))
+
+    return errors
+
+
+def _validate_features(features: dict) -> list[str]:
+    """Validate features field structure and consistency."""
+    errors = []
+
+    if not isinstance(features, dict):
+        errors.append("Field 'features' must be a mapping")
+        return errors
+
+    if "default" not in features:
+        errors.append("Field 'features.default' is required when 'features' is present")
+    if "available" not in features:
+        errors.append("Field 'features.available' is required when 'features' is present")
+        return errors
+
+    available = features.get("available", {})
+    if not isinstance(available, dict):
+        errors.append("Field 'features.available' must be a mapping")
+        return errors
+
+    # Validate each feature definition
+    for feat_name, feat_def in available.items():
+        if not isinstance(feat_def, dict):
+            errors.append(f"Feature '{feat_name}' definition must be a mapping")
+            continue
+
+        if "description" not in feat_def:
+            errors.append(f"Feature '{feat_name}' is missing required field 'description'")
+        if "section" not in feat_def:
+            errors.append(f"Feature '{feat_name}' is missing required field 'section'")
+
+        requires = feat_def.get("requires", [])
+        if isinstance(requires, str):
+            requires = [requires]
+        if not isinstance(requires, list):
+            errors.append(f"Feature '{feat_name}.requires' must be a list")
+        else:
+            for dep in requires:
+                if dep not in available:
+                    errors.append(
+                        f"Feature '{feat_name}' requires unknown feature '{dep}'"
+                    )
+
+    # Validate defaults reference known features
+    default = features.get("default", [])
+    if isinstance(default, str):
+        default = [default]
+    if isinstance(default, list):
+        for d in default:
+            if d not in available:
+                errors.append(f"Default feature '{d}' is not defined in 'features.available'")
+
+    # Validate conflicts reference known features
+    conflicts = features.get("conflicts", [])
+    if isinstance(conflicts, list):
+        for conflict_set in conflicts:
+            if not isinstance(conflict_set, list):
+                errors.append("Each entry in 'features.conflicts' must be a list")
+                continue
+            for c in conflict_set:
+                if c not in available:
+                    errors.append(
+                        f"Conflict references unknown feature '{c}'"
+                    )
 
     return errors
 

--- a/skills-ref/tests/test_features.py
+++ b/skills-ref/tests/test_features.py
@@ -1,0 +1,399 @@
+"""Tests for feature flags support."""
+
+import pytest
+
+from skills_ref.models import FeatureDefinition, Features
+from skills_ref.parser import read_properties
+from skills_ref.validator import validate
+
+
+# --- Model tests ---
+
+
+def test_feature_definition_to_dict_minimal():
+    feat = FeatureDefinition(description="Test", section="## Test")
+    assert feat.to_dict() == {"description": "Test", "section": "## Test"}
+
+
+def test_feature_definition_to_dict_with_requires():
+    feat = FeatureDefinition(description="Test", section="## Test", requires=["other"])
+    assert feat.to_dict() == {
+        "description": "Test",
+        "section": "## Test",
+        "requires": ["other"],
+    }
+
+
+def test_features_to_dict_minimal():
+    features = Features(
+        default=["a"],
+        available={"a": FeatureDefinition(description="A", section="## A")},
+    )
+    result = features.to_dict()
+    assert result == {
+        "default": ["a"],
+        "available": {"a": {"description": "A", "section": "## A"}},
+    }
+
+
+def test_features_to_dict_with_conflicts():
+    features = Features(
+        default=["a"],
+        available={
+            "a": FeatureDefinition(description="A", section="## A"),
+            "b": FeatureDefinition(description="B", section="## B"),
+        },
+        conflicts=[["a", "b"]],
+    )
+    result = features.to_dict()
+    assert result["conflicts"] == [["a", "b"]]
+
+
+# --- Parser tests ---
+
+
+def test_read_properties_with_features(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - app-router\n"
+        "  available:\n"
+        "    app-router:\n"
+        "      description: App Router patterns\n"
+        '      section: "## App Router"\n'
+        "    pages-router:\n"
+        "      description: Pages Router patterns\n"
+        '      section: "## Pages Router"\n'
+        "      requires:\n"
+        "        - app-router\n"
+        "---\n"
+        "# My Skill\n"
+    )
+    props = read_properties(skill_dir)
+    assert props.features is not None
+    assert props.features.default == ["app-router"]
+    assert "app-router" in props.features.available
+    assert "pages-router" in props.features.available
+    assert props.features.available["pages-router"].requires == ["app-router"]
+
+
+def test_read_properties_with_features_and_conflicts(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: Feature A\n"
+        '      section: "## A"\n'
+        "    b:\n"
+        "      description: Feature B\n"
+        '      section: "## B"\n'
+        "  conflicts:\n"
+        "    -\n"
+        "      - a\n"
+        "      - b\n"
+        "---\n"
+        "Body\n"
+    )
+    props = read_properties(skill_dir)
+    assert props.features.conflicts == [["a", "b"]]
+
+
+def test_read_properties_without_features(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.features is None
+
+
+def test_read_properties_features_in_to_dict(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: Feature A\n"
+        '      section: "## A"\n'
+        "---\n"
+        "Body\n"
+    )
+    props = read_properties(skill_dir)
+    d = props.to_dict()
+    assert "features" in d
+    assert d["features"]["default"] == ["a"]
+    assert d["features"]["available"]["a"]["description"] == "Feature A"
+
+
+def test_read_properties_single_default_as_string(tmp_path):
+    """A single default feature can be specified as a string."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default: app-router\n"
+        "  available:\n"
+        "    app-router:\n"
+        "      description: App Router patterns\n"
+        '      section: "## App Router"\n'
+        "---\n"
+        "Body\n"
+    )
+    props = read_properties(skill_dir)
+    assert props.features.default == ["app-router"]
+
+
+# --- Validator tests ---
+
+
+def test_valid_features(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - app-router\n"
+        "  available:\n"
+        "    app-router:\n"
+        "      description: App Router patterns\n"
+        '      section: "## App Router"\n'
+        "    pages-router:\n"
+        "      description: Pages Router patterns\n"
+        '      section: "## Pages Router"\n'
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_features_with_requires_and_conflicts(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - app-router\n"
+        "    - typescript\n"
+        "  available:\n"
+        "    app-router:\n"
+        "      description: App Router\n"
+        '      section: "## App Router"\n'
+        "    pages-router:\n"
+        "      description: Pages Router\n"
+        '      section: "## Pages Router"\n'
+        "    typescript:\n"
+        "      description: TypeScript\n"
+        '      section: "## TypeScript"\n'
+        "    i18n:\n"
+        "      description: i18n\n"
+        '      section: "## i18n"\n'
+        "      requires:\n"
+        "        - app-router\n"
+        "  conflicts:\n"
+        "    -\n"
+        "      - app-router\n"
+        "      - pages-router\n"
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_features_missing_default(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        '      section: "## A"\n'
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("features.default" in e for e in errors)
+
+
+def test_features_missing_available(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("features.available" in e for e in errors)
+
+
+def test_features_default_references_unknown(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - nonexistent\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        '      section: "## A"\n'
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("nonexistent" in e and "not defined" in e for e in errors)
+
+
+def test_features_requires_unknown_feature(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        '      section: "## A"\n'
+        "      requires:\n"
+        "        - nonexistent\n"
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("requires unknown feature 'nonexistent'" in e for e in errors)
+
+
+def test_features_conflict_references_unknown(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        '      section: "## A"\n'
+        "  conflicts:\n"
+        "    -\n"
+        "      - a\n"
+        "      - nonexistent\n"
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("unknown feature 'nonexistent'" in e for e in errors)
+
+
+def test_feature_missing_description(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        '      section: "## A"\n'
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("missing required field 'description'" in e for e in errors)
+
+
+def test_feature_missing_section(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert any("missing required field 'section'" in e for e in errors)
+
+
+def test_features_field_accepted_by_validator(tmp_path):
+    """Ensure 'features' is in ALLOWED_FIELDS and doesn't trigger unexpected fields error."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill\n"
+        "features:\n"
+        "  default:\n"
+        "    - a\n"
+        "  available:\n"
+        "    a:\n"
+        "      description: A\n"
+        '      section: "## A"\n'
+        "---\n"
+        "Body\n"
+    )
+    errors = validate(skill_dir)
+    assert not any("Unexpected fields" in e for e in errors)


### PR DESCRIPTION
## Summary

- Add optional `features` field to SKILL.md frontmatter for declaring sub-capabilities within a skill
- Consumers can activate only relevant sections, reducing context window cost while maintaining a single source of truth
- Update specification docs, reference library (models, parser, validator), and add 19 new tests

## Motivation

Skills face a comprehensiveness vs. context cost tradeoff: a comprehensive skill loads thousands of tokens even when only a fraction is relevant, while splitting into many small skills creates maintenance burden and content duplication. Feature flags let a single skill declare capabilities activated at load time so agents only receive relevant portions.

## Changes

**Specification (`docs/specification.mdx`):**
- Add `features` to the frontmatter field table
- Add `#### features field` section with sub-field tables, example using `pdf-processing`, and documentation for content demarcation, feature resolution, and backward compatibility

**Reference library (`skills-ref/src/skills_ref/`):**
- `models.py`: Add `FeatureDefinition` and `Features` dataclasses with `to_dict()` serialization
- `parser.py`: Parse `features` from frontmatter into typed models, handling both list and string forms for `default`/`requires`
- `validator.py`: Add `features` to `ALLOWED_FIELDS`, validate structure (required sub-fields, dependency references, conflict references, default references)
- `__init__.py`: Export new model classes

**Tests (`skills-ref/tests/test_features.py`):**
- 19 tests covering models, parser, and validator for valid features, missing fields, unknown references, conflicts, and backward compatibility

## Backward compatibility

Purely additive — skills without `features` work exactly as before. Agents that don't understand feature flags load the full SKILL.md as-is.

## Test plan

- [x] All 59 tests pass (40 existing + 19 new)
- [ ] Review spec docs render correctly in Mintlify
- [ ] Validate example SKILL.md with `skills-ref validate`

Resolves #230
Discussion: #229