### PR TITLE
Add skill directory to structure diagram in evaluating skills doc

### DIFF
--- a/docs/skill-creation/evaluating-skills.mdx
+++ b/docs/skill-creation/evaluating-skills.mdx
@@ -54,6 +54,10 @@ The core pattern is to run each test case twice: once **with the skill** and onc
 Organize eval results in a workspace directory alongside your skill directory. Each pass through the full eval loop gets its own `iteration-N/` directory. Within that, each test case gets an eval directory with `with_skill/` and `without_skill/` subdirectories:
 
 ```
+csv-analyzer/
+├── SKILL.md
+└── evals/
+    └── evals.json
 csv-analyzer-workspace/
 └── iteration-1/
     ├── eval-top-months-chart/


### PR DESCRIPTION
Show `csv-analyzer/` (containing `SKILL.md` and `evals/evals.json`) alongside `csv-analyzer-workspace/` so readers can see the full layout at a glance.

Closes #238. Closes #239.