### PR TITLE
Add runtime version example to `compatibility` field

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -135,6 +135,9 @@ compatibility: Designed for Claude Code (or similar products)
 ```yaml
 compatibility: Requires git, docker, jq, and access to the internet
 ```
+```yaml
+compatibility: Requires Python 3.14+ and uv
+```
 </Card>
 
 <Note>


### PR DESCRIPTION
Add a third example showing a Python version requirement alongside `uv`. This complements the existing examples (product targeting and system tool requirements) by demonstrating version-pinned runtime requirements — the kind of non-obvious constraint that the `compatibility` field is useful for.