### PR TITLE
Add ecosystem tools page to docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,12 @@
         "pages": [
           "client-implementation/adding-skills-support"
         ]
+      },
+      {
+        "group": "Ecosystem",
+        "pages": [
+          "ecosystem/tools"
+        ]
       }
     ]
   },

--- a/docs/ecosystem/tools.mdx
+++ b/docs/ecosystem/tools.mdx
@@ -1,0 +1,34 @@
+---
+title: "Ecosystem tools"
+description: "Community-built tools for building, distributing, and validating Agent Skills."
+---
+
+The Agent Skills specification defines the format. These tools help you work with skills at scale.
+
+## Build tools
+
+Build tools compile or generate SKILL.md files from higher-level configuration, enabling skill composition and multi-agent pipeline management.
+
+| Tool | What it does |
+|------|-------------|
+| [skillfold](https://github.com/byronxlg/skillfold) | Compiles YAML config into SKILL.md files. Handles skill composition, typed state schemas, and team execution flows with orchestrator generation. |
+
+## Distribution tools
+
+Distribution tools help package and discover skills across projects and package managers.
+
+| Tool | What it does |
+|------|-------------|
+| [npm-agentskills](https://github.com/onmax/npm-agentskills) | Scans `node_modules` for packages declaring skills via an `agentskills` field in `package.json`. CLI for listing and exporting skills to agent-specific directories. |
+
+## Validation tools
+
+Validation tools check that skills conform to the Agent Skills specification.
+
+| Tool | What it does |
+|------|-------------|
+| [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) | Reference library for validating SKILL.md files and generating prompt XML. Ships with this repository. |
+
+<Note>
+Know of a tool that should be listed here? [Open an issue](https://github.com/agentskills/agentskills/issues) or submit a PR.
+</Note>


### PR DESCRIPTION
Adds an **Ecosystem** section to the docs navigation with an initial **Tools** page that catalogs community-built tooling for Agent Skills.

## What this adds

- `docs/ecosystem/tools.mdx` - New page covering three categories of tooling:
  - **Build tools** - Tools that compile/generate SKILL.md files from higher-level config
  - **Distribution tools** - Tools for packaging and discovering skills via package managers
  - **Validation tools** - Tools for checking spec compliance
- Updated `docs/docs.json` - Adds an "Ecosystem" navigation group

## Why

As the ecosystem grows (32+ platforms), people are building tooling on top of the Agent Skills format. The docs currently cover the spec and skill creation but have no place to list tools that help manage skills at scale. This page gives the community a home for that.

Addresses #264.

## Tools listed

| Tool | Category |
|------|----------|
| [skillfold](https://github.com/byronxlg/skillfold) | Build |
| [npm-agentskills](https://github.com/onmax/npm-agentskills) | Distribution |
| [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) | Validation |

The page includes a note inviting others to submit PRs to add their tools.