### PR TITLE
Clarify that optional directories are not an exhaustive list

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -186,6 +186,8 @@ Note that the agent will load this entire file once it's decided to activate a s
 
 ## Optional directories
 
+A skill directory may contain any files and directories beyond the required `SKILL.md`. The conventions below are recommendations for organizing common types of content.
+
 ### `scripts/`
 
 Contains executable code that agents can run. Scripts should:


### PR DESCRIPTION
Add a note under `## Optional directories` stating that skill directories may contain any files and directories beyond `SKILL.md`, and that the listed directories are recommendations, not requirements. This prevents misreading the section as a closed set of allowed directories.