### PR TITLE
Add Discord links to `README.md` and `docs/home.mdx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Skills are folders of instructions, scripts, and resources that agents can disco
 
 ## Getting Started
 
-- [Documentation](https://agentskills.io) - Guides and tutorials
-- [Specification](https://agentskills.io/specification) - Format details
-- [Example Skills](https://github.com/anthropics/skills) - See what's possible
+- **[Documentation](https://agentskills.io)** — Guides and tutorials
+- **[Specification](https://agentskills.io/specification)** — Format details
+- **[Example Skills](https://github.com/anthropics/skills)** — See what's possible
+- **[Discord](https://discord.gg/MKPE9g8aUy)** — Join the discussion!
 
 This repo contains the specification, documentation, and reference SDK. Also see a list of example skills [here](https://github.com/anthropics/skills).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,6 +8,10 @@
     "dark": "#404040"
   },
   "favicon": "/favicon.svg",
+  "banner": {
+    "content": "Agent Skills now has an official [Discord server](https://discord.gg/MKPE9g8aUy). See the [announcement](https://github.com/agentskills/agentskills/discussions/273) for details.",
+    "dismissible": true
+  },
   "navbar": {
     "primary": {
       "type": "github",

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -34,7 +34,7 @@ Agent Skills are supported by leading AI development tools.
 
 The Agent Skills format was originally developed by [Anthropic](https://www.anthropic.com/), released as an open standard, and has been adopted by a growing number of agent products. The standard is open to contributions from the broader ecosystem.
 
-[View on GitHub](https://github.com/agentskills/agentskills)
+Come join the discussion on [GitHub](https://github.com/agentskills/agentskills) or [Discord](https://discord.gg/MKPE9g8aUy)!
 
 ## Get started
 


### PR DESCRIPTION
Adds a Discord entry to the Getting Started list in `README.md` and replaces the standalone "View on GitHub" link in `docs/home.mdx` with a sentence inviting readers to join on GitHub or Discord.

Also applies minor formatting cleanup in `README.md`: bolds the link text and switches hyphens to em dashes for consistency.