### PR TITLE
feat: add Claude Code frontmatter fields to validator

### DIFF
--- a/skills-ref/src/skills_ref/models.py
+++ b/skills-ref/src/skills_ref/models.py
@@ -11,8 +11,11 @@ class SkillProperties:
     Attributes:
         name: Skill name in kebab-case (required)
         description: What the skill does and when the model should use it (required)
-        license: License for the skill (optional)
+        argument_hint: Hint for arguments the skill accepts (optional, Claude Code)
         compatibility: Compatibility information for the skill (optional)
+        disable_model_invocation: Prevent programmatic invocation (optional, Claude Code)
+        license: License for the skill (optional)
+        model: Model override for the skill (optional, Claude Code)
         allowed_tools: Tool patterns the skill requires (optional, experimental)
         metadata: Key-value pairs for client-specific properties (defaults to
             empty dict; omitted from to_dict() output when empty)
@@ -20,18 +23,27 @@ class SkillProperties:
 
     name: str
     description: str
-    license: Optional[str] = None
+    argument_hint: Optional[str] = None
     compatibility: Optional[str] = None
+    disable_model_invocation: Optional[bool] = None
+    license: Optional[str] = None
+    model: Optional[str] = None
     allowed_tools: Optional[str] = None
     metadata: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         """Convert to dictionary, excluding None values."""
         result = {"name": self.name, "description": self.description}
-        if self.license is not None:
-            result["license"] = self.license
+        if self.argument_hint is not None:
+            result["argument-hint"] = self.argument_hint
         if self.compatibility is not None:
             result["compatibility"] = self.compatibility
+        if self.disable_model_invocation is not None:
+            result["disable-model-invocation"] = self.disable_model_invocation
+        if self.license is not None:
+            result["license"] = self.license
+        if self.model is not None:
+            result["model"] = self.model
         if self.allowed_tools is not None:
             result["allowed-tools"] = self.allowed_tools
         if self.metadata:

--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -102,11 +102,19 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if not isinstance(description, str) or not description.strip():
         raise ValidationError("Field 'description' must be a non-empty string")
 
+    raw_disable = metadata.get("disable-model-invocation")
+    disable_model_invocation = None
+    if raw_disable is not None:
+        disable_model_invocation = str(raw_disable).lower() in ("true", "yes", "1")
+
     return SkillProperties(
         name=name.strip(),
         description=description.strip(),
-        license=metadata.get("license"),
+        argument_hint=metadata.get("argument-hint"),
         compatibility=metadata.get("compatibility"),
+        disable_model_invocation=disable_model_invocation,
+        license=metadata.get("license"),
+        model=metadata.get("model"),
         allowed_tools=metadata.get("allowed-tools"),
         metadata=metadata.get("metadata"),
     )

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -11,14 +11,17 @@ MAX_SKILL_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 MAX_COMPATIBILITY_LENGTH = 500
 
-# Allowed frontmatter fields per Agent Skills Spec
+# Allowed frontmatter fields per Agent Skills Spec + Claude Code extensions
 ALLOWED_FIELDS = {
-    "name",
-    "description",
-    "license",
     "allowed-tools",
-    "metadata",
+    "argument-hint",
     "compatibility",
+    "description",
+    "disable-model-invocation",
+    "license",
+    "metadata",
+    "model",
+    "name",
 }
 
 

--- a/skills-ref/tests/test_parser.py
+++ b/skills-ref/tests/test_parser.py
@@ -170,6 +170,29 @@ description: A test skill
     assert props.description == "A test skill"
 
 
+def test_read_with_claude_code_fields(tmp_path):
+    """Claude Code fields (model, argument-hint, disable-model-invocation) should be parsed."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+model: sonnet
+argument-hint: "[ticket-key]"
+disable-model-invocation: true
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.model == "sonnet"
+    assert props.argument_hint == "[ticket-key]"
+    assert props.disable_model_invocation is True
+    d = props.to_dict()
+    assert d["model"] == "sonnet"
+    assert d["argument-hint"] == "[ticket-key]"
+    assert d["disable-model-invocation"] is True
+
+
 def test_read_with_allowed_tools(tmp_path):
     """allowed-tools should be parsed into SkillProperties."""
     skill_dir = tmp_path / "my-skill"

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -264,6 +264,69 @@ Body
     assert any("exceeds" in e and "500" in e for e in errors)
 
 
+def test_model_field_accepted(tmp_path):
+    """Claude Code 'model' frontmatter field should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+model: sonnet
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_argument_hint_field_accepted(tmp_path):
+    """Claude Code 'argument-hint' frontmatter field should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+argument-hint: "[ticket-key]"
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_disable_model_invocation_field_accepted(tmp_path):
+    """Claude Code 'disable-model-invocation' frontmatter field should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+disable-model-invocation: true
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_all_claude_code_fields_accepted(tmp_path):
+    """All Claude Code frontmatter fields should be accepted together."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+model: sonnet
+argument-hint: "[ticket-key]"
+disable-model-invocation: true
+allowed-tools: Read, Grep
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
 def test_nfkc_normalization(tmp_path):
     """Skill names are NFKC normalized before validation.
 


### PR DESCRIPTION
The skills-ref validator rejects `model`, `argument-hint`, and `disable-model-invocation`, which are standard frontmatter fields in Claude Code's skill spec. Any skill using them fails validation, so we can't run skills-ref in CI for Claude Code plugin repos.

This adds the three fields to `ALLOWED_FIELDS` and wires them through the data model (`SkillProperties`, `read_properties()`, `to_dict()`) so downstream consumers get them too. `disable-model-invocation` is coerced to bool since YAML parses `true` as a string in strictyaml.

Five new tests cover each field individually, all three combined, and a round-trip through `read_properties()`.
