### PR TITLE
Replace nested hexagon favicon with solid hexagon

### DIFF
--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,4 +1,3 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M16 0.5L29.4234 8.25V23.75L16 31.5L2.57661 23.75V8.25L16 0.5Z" fill="black"/>
-<path d="M16 6L24.6603 11V21L16 26L7.33975 21V11L16 6Z" fill="black" stroke="white" stroke-width="3"/>
 </svg>


### PR DESCRIPTION
Remove the inner hexagon path with white stroke from `docs/favicon.svg`, leaving a single solid black hexagon to match the updated logo.