### PR TITLE
Accept YAML lists for allowed-tools; normalize and validate to space-delimited string

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -29,7 +29,7 @@ The `SKILL.md` file must contain YAML frontmatter followed by Markdown content.
 | `license` | No | License name or reference to a bundled license file. |
 | `compatibility` | No | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata. |
-| `allowed-tools` | No | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
+| `allowed-tools` | No | Pre-approved tools the skill may use. Accepts either a space-delimited string or a YAML string list. (Experimental) |
 
 <Card>
 **Minimal example:**
@@ -163,13 +163,22 @@ metadata:
 #### `allowed-tools` field
 
 The optional `allowed-tools` field:
-- A space-delimited list of tools that are pre-approved to run
+- Defines tools that are pre-approved to run
+- Accepts either:
+  - A space-delimited string
+  - A YAML sequence of strings
 - Experimental. Support for this field may vary between agent implementations
 
 <Card>
-**Example:**
+**Examples:**
 ```yaml
 allowed-tools: Bash(git:*) Bash(jq:*) Read
+```
+```yaml
+allowed-tools:
+  - Bash(git:*)
+  - Bash(jq:*)
+  - Read
 ```
 </Card>
 

--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -1,12 +1,33 @@
 """YAML frontmatter parsing for SKILL.md files."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import strictyaml
 
 from .errors import ParseError, ValidationError
 from .models import SkillProperties
+
+
+def _normalize_allowed_tools(value: Any) -> Optional[str]:
+    """Normalize allowed-tools to a space-delimited string.
+
+    Accepts either:
+    - scalar string: "Read Write Bash"
+    - YAML sequence of strings: ["Read", "Write", "Bash"]
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return " ".join(value)
+
+    raise ValidationError(
+        "Field 'allowed-tools' must be either a string or a list of strings"
+    )
 
 
 def find_skill_md(skill_dir: Path) -> Optional[Path]:
@@ -107,6 +128,6 @@ def read_properties(skill_dir: Path) -> SkillProperties:
         description=description.strip(),
         license=metadata.get("license"),
         compatibility=metadata.get("compatibility"),
-        allowed_tools=metadata.get("allowed-tools"),
+        allowed_tools=_normalize_allowed_tools(metadata.get("allowed-tools")),
         metadata=metadata.get("metadata"),
     )

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -101,6 +101,24 @@ def _validate_compatibility(compatibility: str) -> list[str]:
     return errors
 
 
+def _validate_allowed_tools(allowed_tools) -> list[str]:
+    """Validate allowed-tools format."""
+    errors = []
+
+    if isinstance(allowed_tools, str):
+        return errors
+
+    if isinstance(allowed_tools, list):
+        if not all(isinstance(item, str) for item in allowed_tools):
+            errors.append(
+                "Field 'allowed-tools' list items must all be strings"
+            )
+        return errors
+
+    errors.append("Field 'allowed-tools' must be either a string or a list of strings")
+    return errors
+
+
 def _validate_metadata_fields(metadata: dict) -> list[str]:
     """Validate that only allowed fields are present."""
     errors = []
@@ -143,6 +161,9 @@ def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[
 
     if "compatibility" in metadata:
         errors.extend(_validate_compatibility(metadata["compatibility"]))
+
+    if "allowed-tools" in metadata:
+        errors.extend(_validate_allowed_tools(metadata["allowed-tools"]))
 
     return errors
 

--- a/skills-ref/tests/test_parser.py
+++ b/skills-ref/tests/test_parser.py
@@ -186,3 +186,56 @@ Body
     # Verify to_dict outputs as "allowed-tools" (hyphenated)
     d = props.to_dict()
     assert d["allowed-tools"] == "Bash(jq:*) Bash(git:*)"
+
+
+def test_read_with_allowed_tools_inline_list(tmp_path):
+    """allowed-tools inline YAML sequence should be accepted and normalized."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools: [Read, Write, Bash]
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.allowed_tools == "Read Write Bash"
+    d = props.to_dict()
+    assert d["allowed-tools"] == "Read Write Bash"
+
+
+def test_read_with_allowed_tools_block_list(tmp_path):
+    """allowed-tools block YAML sequence should be accepted and normalized."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+---
+Body
+""")
+    props = read_properties(skill_dir)
+    assert props.allowed_tools == "Read Bash Grep"
+
+
+def test_read_with_allowed_tools_invalid_type(tmp_path):
+    """allowed-tools must be either a string or a list of strings."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools: 123
+---
+Body
+""")
+    with pytest.raises(
+        ValidationError,
+        match="allowed-tools' must be either a string or a list of strings",
+    ):
+        read_properties(skill_dir)

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -162,6 +162,73 @@ Body
     assert errors == []
 
 
+def test_allowed_tools_inline_list_accepted(tmp_path):
+    """allowed-tools inline list syntax should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools: [Read, Write, Edit, Bash]
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_allowed_tools_block_list_accepted(tmp_path):
+    """allowed-tools block list syntax should be accepted."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert errors == []
+
+
+def test_allowed_tools_list_items_must_be_strings(tmp_path):
+    """allowed-tools list entries must be strings."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools:
+  - Read
+  - 123
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert any("list items must all be strings" in e for e in errors)
+
+
+def test_allowed_tools_invalid_scalar_type_rejected(tmp_path):
+    """allowed-tools scalar must be a string."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+allowed-tools: 123
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert any(
+        "must be either a string or a list of strings" in e for e in errors
+    )
+
+
 def test_i18n_chinese_name(tmp_path):
     """Chinese characters are allowed in skill names."""
     skill_dir = tmp_path / "技能"


### PR DESCRIPTION
## Summary

This PR resolves #144 by clarifying the `allowed-tools` type and aligning the docs + reference implementation behavior.

### What changed

- Updated the specification to explicitly allow **either**:
  - a space-delimited string, or
  - a YAML sequence of strings.
- Updated `skills-ref` parsing logic to accept both forms and normalize list syntax into the existing space-delimited internal representation.
- Added validation rules so `allowed-tools` must be:
  - a string, or
  - a list of strings.
- Added parser and validator test coverage for:
  - string format,
  - inline list format (`[Read, Write, Bash]`),
  - block list format (`- Read`),
  - invalid scalar type,
  - invalid list item types.

## Why

Community skills currently use both scalar and list YAML forms for `allowed-tools`. Supporting both removes ambiguity, improves compatibility with existing skills, and keeps parser output stable for downstream consumers.

## Testing

Commands run:

- `pytest skills-ref/tests/test_parser.py skills-ref/tests/test_validator.py`
- `PYTHONPATH=skills-ref/src pytest skills-ref/tests/test_parser.py skills-ref/tests/test_validator.py`
- `uv sync`

Result: test execution was blocked in this environment because dependencies could not be downloaded (network tunnel restriction), so full runtime validation could not be completed here.

## Issue

Closes #144