### PR TITLE
Use precise type name for `allowed-tools` field

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -29,7 +29,7 @@ The `SKILL.md` file must contain YAML frontmatter followed by Markdown content.
 | `license` | No | License name or reference to a bundled license file. |
 | `compatibility` | No | Max 500 characters. Indicates environment requirements (intended product, system packages, network access, etc.). |
 | `metadata` | No | Arbitrary key-value mapping for additional metadata. |
-| `allowed-tools` | No | Space-delimited list of pre-approved tools the skill may use. (Experimental) |
+| `allowed-tools` | No | Space-separated string of pre-approved tools the skill may use. (Experimental) |
 
 <Card>
 **Minimal example:**
@@ -163,7 +163,7 @@ metadata:
 #### `allowed-tools` field
 
 The optional `allowed-tools` field:
-- A space-delimited list of tools that are pre-approved to run
+- A space-separated string of tools that are pre-approved to run
 - Experimental. Support for this field may vary between agent implementations
 
 <Card>


### PR DESCRIPTION
Replace "space-delimited list" with "space-separated string" in both the frontmatter table and the `allowed-tools` field section. This better reflects that the value is a YAML scalar, per the given example.