### PR TITLE
Scale down Google AI Edge Gallery logo in `clients.jsx`

### DIFF
--- a/docs/snippets/clients.jsx
+++ b/docs/snippets/clients.jsx
@@ -300,6 +300,7 @@ export const clients = [
     url: "https://github.com/google-ai-edge/gallery",
     lightSrc: "/images/logos/google-ai-edge-gallery/google-ai-edge-gallery-light.svg",
     darkSrc: "/images/logos/google-ai-edge-gallery/google-ai-edge-gallery-dark.svg",
+    scale: 0.45,
     instructionsUrl: "https://github.com/google-ai-edge/gallery/tree/main/skills",
   },
 ];


### PR DESCRIPTION
The logo is a 256x256 square icon with no wordmark, so at default scale it appears much larger than the horizontal wordmark logos used by other clients. Setting `scale: 0.45` brings it in line visually.

| Before | After |
| --- | --- |
| <img width="1848" height="964" alt="before" src="https://github.com/user-attachments/assets/8965583d-9049-4ac2-a8bc-160e5a631aae" /> | <img width="1848" height="964" alt="after" src="https://github.com/user-attachments/assets/f92d75d8-13e9-48ba-bdcf-7f72cd0f60d4" /> |

