### PR TITLE
Add text adopters list to clients page

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -7,3 +7,17 @@ import { clients } from '/snippets/clients.jsx';
 import { ClientShowcase } from '/snippets/ClientShowcase.jsx';
 
 <ClientShowcase clients={clients} />
+
+## Adopters
+
+A text list of agent products that support the Agent Skills format, for users and LLMs that cannot render the logo showcase above. Entries are kept in sync with the showcase.
+
+<ul>
+  {clients.toSorted((a, b) => a.name.localeCompare(b.name)).map((c) => (
+    <li key={c.name}>
+      <a href={c.url}><strong>{c.name}</strong></a> — {c.description}
+      {c.instructionsUrl && <> (<a href={c.instructionsUrl}>setup instructions</a>)</>}
+      {c.sourceCodeUrl && <> (<a href={c.sourceCodeUrl}>source code</a>)</>}
+    </li>
+  ))}
+</ul>


### PR DESCRIPTION
Fixes #323

The clients page currently only shows logos and JSX-rendered descriptions. When LLMs or accessibility tools read the raw page content they cannot easily extract which products adopt Agent Skills.

This PR adds a plain text adopters list below the existing logo showcase. It reuses the existing `clients` data (single source of truth) and renders each entry as a list item with the product name, URL, description, and links to setup instructions / source code where available. Entries are sorted alphabetically for stability.

No new data fields, no navigation changes, no restructuring — the showcase is unchanged.

This PR was written primarily by Claude Code via Orbit.