### PR TITLE
Scale down fast-agent logo in `clients.jsx`

### DIFF
--- a/docs/snippets/clients.jsx
+++ b/docs/snippets/clients.jsx
@@ -327,8 +327,8 @@ export const clients = [
     url: "https://fast-agent.ai/",
     lightSrc: "/images/logos/fast-agent/fast-agent-light.svg",
     darkSrc: "/images/logos/fast-agent/fast-agent-dark.svg",
-    scale: 1.8,
-    instructionsUrl: "https://fast-agent.ai/",
+    scale: 1.33,
+    instructionsUrl: "https://fast-agent.ai/agents/skills/",
     sourceCodeUrl: "https://github.com/evalstate/fast-agent",
-  },  
+  },
 ];


### PR DESCRIPTION
Reduce the `scale` from `1.8` to `1.33` to better match neighboring logos in the showcase. Also point `instructionsUrl` to the Agent Skills page on fast-agent.ai, and trim trailing whitespace.