### PR TITLE
Fix: read SKILL.md as UTF-8 to support non-CP1252 characters on Windows

### DIFF
--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -86,7 +86,7 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if skill_md is None:
         raise ParseError(f"SKILL.md not found in {skill_dir}")
 
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     metadata, _ = parse_frontmatter(content)
 
     if "name" not in metadata:

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -169,7 +169,7 @@ def validate(skill_dir: Path) -> list[str]:
         return ["Missing required file: SKILL.md"]
 
     try:
-        content = skill_md.read_text()
+        content = skill_md.read_text(encoding="utf-8")
         metadata, _ = parse_frontmatter(content)
     except ParseError as e:
         return [str(e)]

--- a/skills-ref/tests/test_parser.py
+++ b/skills-ref/tests/test_parser.py
@@ -67,13 +67,16 @@ Body
 def test_read_valid_skill(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 license: MIT
 ---
 # My Skill
-""")
+""",
+        encoding="utf-8",
+    )
     props = read_properties(skill_dir)
     assert props.name == "my-skill"
     assert props.description == "A test skill"
@@ -83,7 +86,8 @@ license: MIT
 def test_read_with_metadata(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 metadata:
@@ -91,7 +95,9 @@ metadata:
   version: 1.0
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     props = read_properties(skill_dir)
     assert props.metadata == {"author": "Test Author", "version": "1.0"}
 
@@ -104,11 +110,14 @@ def test_missing_skill_md(tmp_path):
 def test_missing_name(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     with pytest.raises(ValidationError, match="Missing required field.*name"):
         read_properties(skill_dir)
 
@@ -116,11 +125,14 @@ Body
 def test_missing_description(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     with pytest.raises(ValidationError, match="Missing required field.*description"):
         read_properties(skill_dir)
 
@@ -129,8 +141,8 @@ def test_find_skill_md_prefers_uppercase(tmp_path):
     """SKILL.md should be preferred over skill.md when both exist."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("uppercase")
-    (skill_dir / "skill.md").write_text("lowercase")
+    (skill_dir / "SKILL.md").write_text("uppercase", encoding="utf-8")
+    (skill_dir / "skill.md").write_text("lowercase", encoding="utf-8")
     result = find_skill_md(skill_dir)
     assert result is not None
     assert result.name == "SKILL.md"
@@ -140,7 +152,7 @@ def test_find_skill_md_accepts_lowercase(tmp_path):
     """skill.md should be accepted when SKILL.md doesn't exist."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "skill.md").write_text("lowercase")
+    (skill_dir / "skill.md").write_text("lowercase", encoding="utf-8")
     result = find_skill_md(skill_dir)
     assert result is not None
     # Check case-insensitively since some filesystems are case-insensitive
@@ -159,28 +171,59 @@ def test_read_properties_with_lowercase_skill_md(tmp_path):
     """read_properties should work with lowercase skill.md."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "skill.md").write_text("""---
+    (skill_dir / "skill.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 ---
 # My Skill
-""")
+""",
+        encoding="utf-8",
+    )
     props = read_properties(skill_dir)
     assert props.name == "my-skill"
     assert props.description == "A test skill"
+
+
+def test_read_properties_utf8_with_non_cp1252_byte(tmp_path):
+    """Regression: read_properties must read SKILL.md as UTF-8.
+
+    Pairs with ``test_utf8_skill_md_with_non_cp1252_byte`` in ``test_validator.py``.
+    On Windows the legacy ``Path.read_text()`` default encoding is CP1252, which
+    crashes on bytes like ``0x8f`` (e.g. the middle byte of U+23F3 ⏳ in UTF-8) and
+    silently corrupts CP1252-defined bytes for non-ASCII characters (em dashes
+    decode as ``â€"``). Both behaviours produce wrong output for real-world skills.
+    """
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    expected_description = "Sleep — pending ⏳ → done."
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: my-skill
+description: {expected_description}
+---
+Body
+""",
+        encoding="utf-8",
+    )
+    props = read_properties(skill_dir)
+    assert props.description == expected_description
 
 
 def test_read_with_allowed_tools(tmp_path):
     """allowed-tools should be parsed into SkillProperties."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 allowed-tools: Bash(jq:*) Bash(git:*)
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     props = read_properties(skill_dir)
     assert props.allowed_tools == "Bash(jq:*) Bash(git:*)"
     # Verify to_dict outputs as "allowed-tools" (hyphenated)

--- a/skills-ref/tests/test_prompt.py
+++ b/skills-ref/tests/test_prompt.py
@@ -11,12 +11,15 @@ def test_empty_list():
 def test_single_skill(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     result = to_prompt([skill_dir])
     assert "<available_skills>" in result
     assert "</available_skills>" in result
@@ -29,21 +32,27 @@ Body
 def test_multiple_skills(tmp_path):
     skill_a = tmp_path / "skill-a"
     skill_a.mkdir()
-    (skill_a / "SKILL.md").write_text("""---
+    (skill_a / "SKILL.md").write_text(
+        """---
 name: skill-a
 description: First skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
 
     skill_b = tmp_path / "skill-b"
     skill_b.mkdir()
-    (skill_b / "SKILL.md").write_text("""---
+    (skill_b / "SKILL.md").write_text(
+        """---
 name: skill-b
 description: Second skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
 
     result = to_prompt([skill_a, skill_b])
     assert result.count("<skill>") == 2
@@ -56,12 +65,15 @@ def test_special_characters_escaped(tmp_path):
     """XML special characters in description are escaped."""
     skill_dir = tmp_path / "special-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: special-skill
 description: Use <foo> & <bar> tags
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     result = to_prompt([skill_dir])
     assert "&lt;foo&gt;" in result
     assert "&amp;" in result

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -6,12 +6,15 @@ from skills_ref.validator import validate
 def test_valid_skill(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 ---
 # My Skill
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -24,7 +27,7 @@ def test_nonexistent_path(tmp_path):
 
 def test_not_a_directory(tmp_path):
     file_path = tmp_path / "file.txt"
-    file_path.write_text("test")
+    file_path.write_text("test", encoding="utf-8")
     errors = validate(file_path)
     assert len(errors) == 1
     assert "Not a directory" in errors[0]
@@ -41,12 +44,15 @@ def test_missing_skill_md(tmp_path):
 def test_invalid_name_uppercase(tmp_path):
     skill_dir = tmp_path / "MySkill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: MySkill
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("lowercase" in e for e in errors)
 
@@ -55,12 +61,15 @@ def test_name_too_long(tmp_path):
     long_name = "a" * 70  # Exceeds 64 char limit
     skill_dir = tmp_path / long_name
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text(f"""---
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
 name: {long_name}
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("exceeds" in e and "character limit" in e for e in errors)
 
@@ -68,12 +77,15 @@ Body
 def test_name_leading_hyphen(tmp_path):
     skill_dir = tmp_path / "-my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: -my-skill
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("cannot start or end with a hyphen" in e for e in errors)
 
@@ -81,12 +93,15 @@ Body
 def test_name_consecutive_hyphens(tmp_path):
     skill_dir = tmp_path / "my--skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my--skill
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("consecutive hyphens" in e for e in errors)
 
@@ -94,12 +109,15 @@ Body
 def test_name_invalid_characters(tmp_path):
     skill_dir = tmp_path / "my_skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my_skill
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("invalid characters" in e for e in errors)
 
@@ -107,12 +125,15 @@ Body
 def test_name_directory_mismatch(tmp_path):
     skill_dir = tmp_path / "wrong-name"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: correct-name
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("must match skill name" in e for e in errors)
 
@@ -120,13 +141,16 @@ Body
 def test_unexpected_fields(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 unknown_field: should not be here
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("Unexpected fields" in e for e in errors)
 
@@ -134,7 +158,8 @@ Body
 def test_valid_with_all_fields(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 license: MIT
@@ -142,7 +167,9 @@ metadata:
   author: Test
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -151,13 +178,16 @@ def test_allowed_tools_accepted(tmp_path):
     """allowed-tools is accepted (experimental feature)."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 allowed-tools: Bash(jq:*) Bash(git:*)
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -166,12 +196,15 @@ def test_i18n_chinese_name(tmp_path):
     """Chinese characters are allowed in skill names."""
     skill_dir = tmp_path / "技能"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: 技能
 description: A skill with Chinese name
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -180,12 +213,15 @@ def test_i18n_russian_name_with_hyphens(tmp_path):
     """Russian names with hyphens are allowed."""
     skill_dir = tmp_path / "мой-навык"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: мой-навык
 description: A skill with Russian name
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -194,12 +230,15 @@ def test_i18n_russian_lowercase_valid(tmp_path):
     """Russian lowercase names should be accepted."""
     skill_dir = tmp_path / "навык"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: навык
 description: A skill with Russian lowercase name
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -208,12 +247,15 @@ def test_i18n_russian_uppercase_rejected(tmp_path):
     """Russian uppercase names should be rejected."""
     skill_dir = tmp_path / "НАВЫК"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: НАВЫК
 description: A skill with Russian uppercase name
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("lowercase" in e for e in errors)
 
@@ -223,12 +265,15 @@ def test_description_too_long(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
     long_desc = "x" * 1100
-    (skill_dir / "SKILL.md").write_text(f"""---
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
 name: my-skill
 description: {long_desc}
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("exceeds" in e and "1024" in e for e in errors)
 
@@ -237,13 +282,16 @@ def test_valid_compatibility(tmp_path):
     """Valid compatibility field should be accepted."""
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text("""---
+    (skill_dir / "SKILL.md").write_text(
+        """---
 name: my-skill
 description: A test skill
 compatibility: Requires Python 3.11+
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == []
 
@@ -253,15 +301,45 @@ def test_compatibility_too_long(tmp_path):
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
     long_compat = "x" * 550
-    (skill_dir / "SKILL.md").write_text(f"""---
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
 name: my-skill
 description: A test skill
 compatibility: {long_compat}
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert any("exceeds" in e and "500" in e for e in errors)
+
+
+def test_utf8_skill_md_with_non_cp1252_byte(tmp_path):
+    """Regression: SKILL.md containing UTF-8 bytes undefined in CP1252 must validate.
+
+    On Windows, ``Path.read_text()`` defaults to the system locale encoding (CP1252),
+    which is undefined for byte ``0x8f`` and several others appearing inside multi-byte
+    UTF-8 sequences. Skills authored in real-world UTF-8 (em dashes, hourglass emoji,
+    other code points) crashed validation on Windows. The validator must read SKILL.md
+    explicitly as UTF-8.
+    """
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    # ⏳ (U+23F3) encodes as 0xe2 0x8f 0xb3 — the middle byte 0x8f is undefined in
+    # CP1252, so the legacy default-encoding read crashes. Em dash and arrow are
+    # CP1252-defined but get mojibake'd if read as CP1252; UTF-8 round-trips them.
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: my-skill
+description: A skill — pending ⏳ → done.
+---
+Body
+""",
+        encoding="utf-8",
+    )
+    errors = validate(skill_dir)
+    assert errors == [], f"Expected no errors, got: {errors}"
 
 
 def test_nfkc_normalization(tmp_path):
@@ -280,11 +358,14 @@ def test_nfkc_normalization(tmp_path):
     # Directory uses composed form, SKILL.md uses decomposed - should match after normalization
     skill_dir = tmp_path / composed_name
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").write_text(f"""---
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
 name: {decomposed_name}
 description: A test skill
 ---
 Body
-""")
+""",
+        encoding="utf-8",
+    )
     errors = validate(skill_dir)
     assert errors == [], f"Expected no errors, got: {errors}"


### PR DESCRIPTION
## Problem

`Path.read_text()` and `Path.write_text()` default to the platform locale encoding. On Windows that's CP1252, where:

- byte `0x8f` is undefined and crashes decoding (e.g. the middle byte of U+23F3 ⏳ in UTF-8 is `0x8f`, so `skills-ref validate` fails outright on any SKILL.md containing the hourglass emoji)
- non-ASCII characters in CP1252's defined range get silently mojibake'd (e.g. a UTF-8 em dash `—` decodes as `â€"` in CP1252, so descriptions read back wrong even when validation appears to pass)

Both behaviours produce wrong output for real-world skills. SKILL.md files in the wild are UTF-8 (the de facto standard for markdown).

## Fix

**Production code (2 lines):**

- `src/skills_ref/validator.py:172` — `read_text()` → `read_text(encoding="utf-8")`
- `src/skills_ref/parser.py:89` — `read_text()` → `read_text(encoding="utf-8")`

**Tests (Windows-compatibility):**

The same `encoding="utf-8"` is propagated to every `.write_text(...)` call across `tests/test_*.py`. Without this, the existing i18n tests (`test_i18n_chinese_name`, `test_i18n_russian_*`, `test_nfkc_normalization`) fail on Windows because they can't write their UTF-8 fixture content under CP1252's encode-side restrictions. The tests were always passing on Linux and macOS where the platform default is UTF-8; this PR makes them pass on Windows too.

## Regression tests

Two new tests cover the exact failure mode:

- `tests/test_validator.py::test_utf8_skill_md_with_non_cp1252_byte`
- `tests/test_parser.py::test_read_properties_utf8_with_non_cp1252_byte`

Both write SKILL.md with `⏳ — →` (covering the crash byte 0x8f and the mojibake-prone CP1252-defined bytes) and assert correct round-tripping. They fail on the unpatched code with `UnicodeDecodeError` on `0x8f` and pass after the encoding fix.

## Verification

- **Test suite:** 42/42 passing on Windows (was 37/42 — five i18n/normalization tests previously broken on Windows now pass).
- **Ruff:** `ruff format --check` clean, `ruff check` clean.

## How I found it

Validating two skills authored on Windows. The first (`continuation-prompt`) passed because its non-ASCII chars happened to be CP1252-defined (em dashes). The second (`project-memory-update`) crashed because of one ⏳ emoji. Reading the traceback led to `validator.py:172`'s unannotated `read_text()`. Same pattern in `parser.py:89`. Same pattern across 28 test fixture sites.