### PR TITLE
Add `--allow-field` option to `skills-ref validate`

### DIFF
--- a/skills-ref/src/skills_ref/cli.py
+++ b/skills-ref/src/skills_ref/cli.py
@@ -1,6 +1,7 @@
 """CLI for skills-ref library."""
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -10,6 +11,8 @@ from .errors import SkillError
 from .parser import read_properties
 from .prompt import to_prompt
 from .validator import validate
+
+_FIELD_NAME_RE = re.compile(r"^[a-z]+(-[a-z]+)*$")
 
 
 def _is_skill_md_file(path: Path) -> bool:
@@ -26,7 +29,12 @@ def main():
 
 @main.command("validate")
 @click.argument("skill_path", type=click.Path(exists=True, path_type=Path))
-def validate_cmd(skill_path: Path):
+@click.option(
+    "--allow-field",
+    multiple=True,
+    help="Additional frontmatter field to allow (repeatable).",
+)
+def validate_cmd(skill_path: Path, allow_field: tuple[str, ...]):
     """Validate a skill directory.
 
     Checks that the skill has a valid SKILL.md with proper frontmatter,
@@ -39,7 +47,20 @@ def validate_cmd(skill_path: Path):
     if _is_skill_md_file(skill_path):
         skill_path = skill_path.parent
 
-    errors = validate(skill_path)
+    if allow_field:
+        invalid = [f for f in allow_field if not _FIELD_NAME_RE.match(f)]
+        if invalid:
+            click.echo(
+                f"Error: invalid --allow-field value: {', '.join(repr(f) for f in invalid)}. "
+                "Field names must be lowercase ASCII letters separated by single hyphens "
+                "(e.g. 'user-invocable').",
+                err=True,
+            )
+            sys.exit(1)
+        extra = set(allow_field)
+    else:
+        extra = None
+    errors = validate(skill_path, extra_allowed_fields=extra)
 
     if errors:
         click.echo(f"Validation failed for {skill_path}:", err=True)

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -101,21 +101,28 @@ def _validate_compatibility(compatibility: str) -> list[str]:
     return errors
 
 
-def _validate_metadata_fields(metadata: dict) -> list[str]:
+def _validate_metadata_fields(
+    metadata: dict, extra_allowed_fields: set[str] | None = None
+) -> list[str]:
     """Validate that only allowed fields are present."""
     errors = []
 
-    extra_fields = set(metadata.keys()) - ALLOWED_FIELDS
+    allowed = ALLOWED_FIELDS | (extra_allowed_fields or set())
+    extra_fields = set(metadata.keys()) - allowed
     if extra_fields:
         errors.append(
             f"Unexpected fields in frontmatter: {', '.join(sorted(extra_fields))}. "
-            f"Only {sorted(ALLOWED_FIELDS)} are allowed."
+            f"Only {sorted(allowed)} are allowed."
         )
 
     return errors
 
 
-def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[str]:
+def validate_metadata(
+    metadata: dict,
+    skill_dir: Optional[Path] = None,
+    extra_allowed_fields: set[str] | None = None,
+) -> list[str]:
     """Validate parsed skill metadata.
 
     This is the core validation function that works on already-parsed metadata,
@@ -124,12 +131,13 @@ def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[
     Args:
         metadata: Parsed YAML frontmatter dictionary
         skill_dir: Optional path to skill directory (for name-directory match check)
+        extra_allowed_fields: Additional field names to accept in frontmatter
 
     Returns:
         List of validation error messages. Empty list means valid.
     """
     errors = []
-    errors.extend(_validate_metadata_fields(metadata))
+    errors.extend(_validate_metadata_fields(metadata, extra_allowed_fields))
 
     if "name" not in metadata:
         errors.append("Missing required field in frontmatter: name")
@@ -147,11 +155,14 @@ def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[
     return errors
 
 
-def validate(skill_dir: Path) -> list[str]:
+def validate(
+    skill_dir: Path, extra_allowed_fields: set[str] | None = None
+) -> list[str]:
     """Validate a skill directory.
 
     Args:
         skill_dir: Path to the skill directory
+        extra_allowed_fields: Additional field names to accept in frontmatter
 
     Returns:
         List of validation error messages. Empty list means valid.
@@ -174,4 +185,4 @@ def validate(skill_dir: Path) -> list[str]:
     except ParseError as e:
         return [str(e)]
 
-    return validate_metadata(metadata, skill_dir)
+    return validate_metadata(metadata, skill_dir, extra_allowed_fields)

--- a/skills-ref/tests/test_cli.py
+++ b/skills-ref/tests/test_cli.py
@@ -1,0 +1,157 @@
+"""Tests for CLI --allow-field option."""
+
+from click.testing import CliRunner
+
+from skills_ref.cli import main
+
+
+def test_allow_field_single(tmp_path):
+    """Single --allow-field flag suppresses error for that field."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["validate", "--allow-field", "user-invocable", str(skill_dir)]
+    )
+    assert result.exit_code == 0
+
+
+def test_allow_field_empty_value_rejected(tmp_path):
+    """Empty --allow-field value produces an error."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(main, ["validate", "--allow-field", "", str(skill_dir)])
+    assert result.exit_code == 1
+    assert "invalid --allow-field value" in result.output
+
+
+def test_allow_field_invalid_characters_rejected(tmp_path):
+    """Field names with invalid characters are rejected."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["validate", "--allow-field", "User_Invocable", str(skill_dir)]
+    )
+    assert result.exit_code == 1
+    assert "invalid --allow-field value" in result.output
+    assert "lowercase ASCII letters separated by single hyphens" in result.output
+
+
+def test_allow_field_partial_coverage(tmp_path):
+    """Fields not covered by --allow-field still cause validation failure."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+totally-bogus: wat
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["validate", "--allow-field", "user-invocable", str(skill_dir)]
+    )
+    assert result.exit_code == 1
+    assert "totally-bogus" in result.output
+
+
+def test_allow_field_mixed_valid_and_invalid(tmp_path):
+    """Only invalid values are reported; valid values are not flagged."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "validate",
+            "--allow-field",
+            "good-name",
+            "--allow-field",
+            "Bad_Name",
+            "--allow-field",
+            "also-good",
+            "--allow-field",
+            "123bad",
+            str(skill_dir),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "'Bad_Name'" in result.output
+    assert "'123bad'" in result.output
+    assert "good-name" not in result.output
+    assert "also-good" not in result.output
+
+
+def test_allow_field_with_skill_md_file_path(tmp_path):
+    """--allow-field works when user passes a SKILL.md file path."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["validate", "--allow-field", "user-invocable", str(skill_md)]
+    )
+    assert result.exit_code == 0
+
+
+def test_allow_field_multiple(tmp_path):
+    """Multiple --allow-field flags all work."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+model: opus
+---
+Body
+""")
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "validate",
+            "--allow-field",
+            "user-invocable",
+            "--allow-field",
+            "model",
+            str(skill_dir),
+        ],
+    )
+    assert result.exit_code == 0

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -264,6 +264,56 @@ Body
     assert any("exceeds" in e and "500" in e for e in errors)
 
 
+def test_extra_allowed_fields_accepted(tmp_path):
+    """Extra fields specified via parameter are not flagged."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+model: opus
+---
+Body
+""")
+    errors = validate(skill_dir, extra_allowed_fields={"user-invocable", "model"})
+    assert errors == []
+
+
+def test_extra_allowed_fields_still_rejects_unknown(tmp_path):
+    """Fields not in base set OR extra set are still rejected."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+totally-bogus: wat
+---
+Body
+""")
+    errors = validate(skill_dir, extra_allowed_fields={"user-invocable"})
+    assert len(errors) == 1
+    assert "Unexpected fields in frontmatter: totally-bogus" in errors[0]
+    assert "user-invocable" in errors[0]
+
+
+def test_extra_allowed_fields_none_backward_compatible(tmp_path):
+    """Passing None (default) preserves original strict behavior."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+user-invocable: true
+---
+Body
+""")
+    errors = validate(skill_dir)
+    assert len(errors) == 1
+    assert "Unexpected fields in frontmatter: user-invocable" in errors[0]
+
+
 def test_nfkc_normalization(tmp_path):
     """Skill names are NFKC normalized before validation.
 


### PR DESCRIPTION
## Summary

- Adds a repeatable `--allow-field` CLI flag and `extra_allowed_fields` Python API parameter to `skills-ref validate`
- Validates field names against the spec pattern (lowercase ASCII letters separated by single hyphens)
- Fully backward-compatible — existing usage without the flag behaves identically

## Motivation

Relates to #105.

`skills-ref validate` enforces a hardcoded allowlist of six frontmatter fields. Different runtimes and toolchains extend SKILL.md frontmatter with their own fields — Claude Code uses `user-invocable` and `model`, others may use `context`, `hooks`, `agent`, `argument-hint`, or fields we haven't anticipated yet.

Today, any skill using a custom field fails validation. It's impossible to predict all the fields users will need, and hardcoding each one requires a spec change and a `skills-ref` release — that doesn't scale.

## Approach

Instead of expanding the hardcoded allowlist every time a new field emerges, let users declare which additional fields their environment requires:

```bash
skills-ref validate --allow-field user-invocable --allow-field model ./my-skill
```

```python
from skills_ref import validate
errors = validate(Path("my-skill"), extra_allowed_fields={"user-invocable", "model"})
```

This solves the general case with minimal surface area — one parameter, one CLI flag. The base spec fields remain enforced by default, and the escape hatch is explicit and auditable (visible in CI scripts, pre-commit configs, etc.). Users can validate with whatever their preferred tooling requires without waiting on upstream spec changes.

## Test plan

- [x] `uv run pytest` — 48 tests pass (8 new)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Verify: custom fields covered by `--allow-field` pass validation
- [x] Verify: unknown fields not covered by `--allow-field` still fail
- [x] Verify: empty or malformed `--allow-field` values produce a clear error
- [x] Verify: `--allow-field` works with both directory and SKILL.md file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)