### PR TITLE
Add optional evals validation to skills-ref

### DIFF
--- a/skills-ref/README.md
+++ b/skills-ref/README.md
@@ -59,6 +59,9 @@ After installation, the `skills-ref` executable will be available on your `PATH`
 # Validate a skill
 skills-ref validate path/to/skill
 
+# Also validate evals/evals.json
+skills-ref validate --evals path/to/skill
+
 # Read skill properties (outputs JSON)
 skills-ref read-properties path/to/skill
 

--- a/skills-ref/src/skills_ref/__init__.py
+++ b/skills-ref/src/skills_ref/__init__.py
@@ -4,7 +4,7 @@ from .errors import ParseError, SkillError, ValidationError
 from .models import SkillProperties
 from .parser import find_skill_md, read_properties
 from .prompt import to_prompt
-from .validator import validate
+from .validator import validate, validate_evals
 
 __all__ = [
     "SkillError",
@@ -13,6 +13,7 @@ __all__ = [
     "SkillProperties",
     "find_skill_md",
     "validate",
+    "validate_evals",
     "read_properties",
     "to_prompt",
 ]

--- a/skills-ref/src/skills_ref/cli.py
+++ b/skills-ref/src/skills_ref/cli.py
@@ -26,11 +26,18 @@ def main():
 
 @main.command("validate")
 @click.argument("skill_path", type=click.Path(exists=True, path_type=Path))
-def validate_cmd(skill_path: Path):
+@click.option(
+    "--evals",
+    "include_evals",
+    is_flag=True,
+    help="Also validate evals/evals.json.",
+)
+def validate_cmd(skill_path: Path, include_evals: bool):
     """Validate a skill directory.
 
     Checks that the skill has a valid SKILL.md with proper frontmatter,
-    correct naming conventions, and required fields.
+    correct naming conventions, and required fields. Pass --evals to also
+    validate evals/evals.json.
 
     Exit codes:
         0: Valid skill
@@ -39,7 +46,7 @@ def validate_cmd(skill_path: Path):
     if _is_skill_md_file(skill_path):
         skill_path = skill_path.parent
 
-    errors = validate(skill_path)
+    errors = validate(skill_path, include_evals=include_evals)
 
     if errors:
         click.echo(f"Validation failed for {skill_path}:", err=True)

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -1,5 +1,6 @@
 """Skill validation logic."""
 
+import json
 import unicodedata
 from pathlib import Path
 from typing import Optional
@@ -10,6 +11,7 @@ from .parser import find_skill_md, parse_frontmatter
 MAX_SKILL_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 MAX_COMPATIBILITY_LENGTH = 500
+EVALS_PATH = Path("evals") / "evals.json"
 
 # Allowed frontmatter fields per Agent Skills Spec
 ALLOWED_FIELDS = {
@@ -147,11 +149,94 @@ def validate_metadata(metadata: dict, skill_dir: Optional[Path] = None) -> list[
     return errors
 
 
-def validate(skill_dir: Path) -> list[str]:
+def _validate_string_field(value: object, path: str) -> list[str]:
+    """Validate a required non-empty string field."""
+    if not isinstance(value, str) or not value.strip():
+        return [f"Field '{path}' must be a non-empty string"]
+    return []
+
+
+def _validate_string_list(value: object, path: str) -> list[str]:
+    """Validate an optional list of non-empty strings."""
+    errors = []
+    if not isinstance(value, list):
+        return [f"Field '{path}' must be a list of strings"]
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"Field '{path}[{index}]' must be a non-empty string")
+
+    return errors
+
+
+def validate_evals(skill_dir: Path) -> list[str]:
+    """Validate evals/evals.json for a skill directory.
+
+    Args:
+        skill_dir: Path to the skill directory
+
+    Returns:
+        List of validation error messages. Empty list means valid.
+    """
+    evals_path = Path(skill_dir) / EVALS_PATH
+    if not evals_path.exists():
+        return [f"Missing optional evals file requested for validation: {EVALS_PATH}"]
+
+    try:
+        data = json.loads(evals_path.read_text())
+    except json.JSONDecodeError as e:
+        return [f"Invalid JSON in {EVALS_PATH}: {e.msg} at line {e.lineno}, column {e.colno}"]
+
+    errors = []
+    if not isinstance(data, dict):
+        return [f"{EVALS_PATH} must contain a JSON object"]
+
+    errors.extend(_validate_string_field(data.get("skill_name"), "skill_name"))
+
+    evals = data.get("evals")
+    if not isinstance(evals, list) or not evals:
+        errors.append("Field 'evals' must be a non-empty list")
+        return errors
+
+    seen_ids = set()
+    for index, eval_case in enumerate(evals):
+        prefix = f"evals[{index}]"
+        if not isinstance(eval_case, dict):
+            errors.append(f"Field '{prefix}' must be an object")
+            continue
+
+        eval_id = eval_case.get("id")
+        if not isinstance(eval_id, (str, int)) or isinstance(eval_id, bool) or not str(eval_id).strip():
+            errors.append(f"Field '{prefix}.id' must be a non-empty string or integer")
+        elif eval_id in seen_ids:
+            errors.append(f"Field '{prefix}.id' must be unique")
+        else:
+            seen_ids.add(eval_id)
+
+        errors.extend(_validate_string_field(eval_case.get("prompt"), f"{prefix}.prompt"))
+        errors.extend(
+            _validate_string_field(
+                eval_case.get("expected_output"), f"{prefix}.expected_output"
+            )
+        )
+
+        if "files" in eval_case:
+            errors.extend(_validate_string_list(eval_case["files"], f"{prefix}.files"))
+
+        if "assertions" in eval_case:
+            errors.extend(
+                _validate_string_list(eval_case["assertions"], f"{prefix}.assertions")
+            )
+
+    return errors
+
+
+def validate(skill_dir: Path, include_evals: bool = False) -> list[str]:
     """Validate a skill directory.
 
     Args:
         skill_dir: Path to the skill directory
+        include_evals: Whether to validate evals/evals.json
 
     Returns:
         List of validation error messages. Empty list means valid.
@@ -174,4 +259,8 @@ def validate(skill_dir: Path) -> list[str]:
     except ParseError as e:
         return [str(e)]
 
-    return validate_metadata(metadata, skill_dir)
+    errors = validate_metadata(metadata, skill_dir)
+    if include_evals:
+        errors.extend(validate_evals(skill_dir))
+
+    return errors

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -1,6 +1,18 @@
 """Tests for validator module."""
 
-from skills_ref.validator import validate
+import json
+
+from skills_ref.validator import validate, validate_evals
+
+
+def write_valid_skill(skill_dir):
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("""---
+name: my-skill
+description: A test skill
+---
+# My Skill
+""")
 
 
 def test_valid_skill(tmp_path):
@@ -288,3 +300,101 @@ Body
 """)
     errors = validate(skill_dir)
     assert errors == [], f"Expected no errors, got: {errors}"
+
+
+def test_validate_evals_accepts_valid_evals_file(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    write_valid_skill(skill_dir)
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text(json.dumps({
+        "skill_name": "my-skill",
+        "evals": [
+            {
+                "id": "chart",
+                "prompt": "Create a chart from sales.csv",
+                "expected_output": "A labeled chart",
+                "files": ["evals/files/sales.csv"],
+                "assertions": ["The chart has labeled axes"],
+            }
+        ],
+    }))
+
+    assert validate_evals(skill_dir) == []
+    assert validate(skill_dir, include_evals=True) == []
+
+
+def test_validate_does_not_require_evals_by_default(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    write_valid_skill(skill_dir)
+
+    assert validate(skill_dir) == []
+    assert validate(skill_dir, include_evals=True) == [
+        "Missing optional evals file requested for validation: evals/evals.json"
+    ]
+
+
+def test_validate_evals_rejects_invalid_json(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    write_valid_skill(skill_dir)
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text("{")
+
+    errors = validate_evals(skill_dir)
+
+    assert len(errors) == 1
+    assert "Invalid JSON in evals/evals.json" in errors[0]
+
+
+def test_validate_evals_rejects_missing_required_fields(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    write_valid_skill(skill_dir)
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text(json.dumps({
+        "skill_name": "",
+        "evals": [
+            {
+                "id": "",
+                "prompt": "",
+                "files": ["evals/files/input.csv", ""],
+                "assertions": "not a list",
+            }
+        ],
+    }))
+
+    errors = validate_evals(skill_dir)
+
+    assert "Field 'skill_name' must be a non-empty string" in errors
+    assert "Field 'evals[0].id' must be a non-empty string or integer" in errors
+    assert "Field 'evals[0].prompt' must be a non-empty string" in errors
+    assert "Field 'evals[0].expected_output' must be a non-empty string" in errors
+    assert "Field 'evals[0].files[1]' must be a non-empty string" in errors
+    assert "Field 'evals[0].assertions' must be a list of strings" in errors
+
+
+def test_validate_evals_rejects_duplicate_ids(tmp_path):
+    skill_dir = tmp_path / "my-skill"
+    write_valid_skill(skill_dir)
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text(json.dumps({
+        "skill_name": "my-skill",
+        "evals": [
+            {
+                "id": 1,
+                "prompt": "First prompt",
+                "expected_output": "First output",
+            },
+            {
+                "id": 1,
+                "prompt": "Second prompt",
+                "expected_output": "Second output",
+            },
+        ],
+    }))
+
+    errors = validate_evals(skill_dir)
+
+    assert "Field 'evals[1].id' must be unique" in errors


### PR DESCRIPTION
## Summary
- Add optional `evals/evals.json` validation to `skills-ref validate --evals`
- Export `validate_evals` from the Python package
- Cover valid eval files, missing files, malformed JSON, missing fields, bad list fields, and duplicate IDs

## Testing
- `uv run pytest`
- `uv run ruff check .`