### PR TITLE
feat: add optional skill versioning to .well-known spec

### DIFF
--- a/docs/well-known-uri.mdx
+++ b/docs/well-known-uri.mdx
@@ -144,11 +144,22 @@ The `version` field on a skill entry is optional and carries a [semantic version
 
 ### Versioned index paths
 
-Publishers that want clients to be able to fetch or pin a specific version should serve immutable index snapshots at a predictable versioned path alongside the mutable latest:
+Publishers that want clients to be able to fetch or pin a specific version should serve immutable index snapshots at a predictable versioned path alongside the mutable latest, and a `versions.json` file enumerating all available versions:
 
 ```
 https://example.com/.well-known/agent-skills/index.json          ← latest (mutable)
+https://example.com/.well-known/agent-skills/versions.json       ← version list (mutable)
 https://example.com/.well-known/agent-skills/v0.1.1/index.json   ← pinned snapshot (immutable)
+https://example.com/.well-known/agent-skills/v0.2.0/index.json   ← pinned snapshot (immutable)
+```
+
+`versions.json` allows clients to discover which versions are available without probing paths blindly — the same problem solved by [npm's packument](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md) (`versions` object listing all published versions) and [Cargo's registry index](https://doc.rust-lang.org/cargo/reference/registry-index.html) (one file per crate listing every version as a JSON line).
+
+```json /.well-known/agent-skills/versions.json
+{
+  "latest": "0.2.0",
+  "versions": ["0.1.0", "0.1.1", "0.2.0"]
+}
 ```
 
 A versioned index has the same shape as the canonical index. Skill `url` values are resolved per [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5) using the versioned index URL as the base URI, so relative URLs resolve correctly within the versioned path.

--- a/docs/well-known-uri.mdx
+++ b/docs/well-known-uri.mdx
@@ -55,6 +55,7 @@ The index enumerates all available skills, enabling clients to discover them in 
 | `type` | Yes | `"skill-md"` (single `SKILL.md` file) or `"archive"` (bundled archive — see [Archive distribution](#archive-distribution) ). |
 | `url` | Yes | URL to the skill artifact. For `"skill-md"`, points to the `SKILL.md` file. For `"archive"`, points to the archive file. See [URL resolution](#url-resolution). |
 | `digest` | Yes | SHA-256 content digest of the artifact, formatted as `sha256:{hex}` (64 lowercase hex characters). See [Integrity and verification](#integrity-and-verification). |
+| `version` | No | Semantic version of the skill artifact (e.g. `"1.2.0"`). See [Skill versioning](#skill-versioning). |
 
 Clients should ignore unrecognized fields. Clients should skip entries with an unrecognized `type` value and warn the user.
 
@@ -136,6 +137,55 @@ For `"type": "skill-md"`, the artifact is the `SKILL.md` file. For `"type": "arc
 Clients must verify downloaded content against the `digest` in the index. A mismatch indicates the content is corrupted or tampered with — clients must not use unverified content.
 
 Digests also enable efficient caching: compare a skill's `digest` against a locally cached value to determine whether the artifact has changed without re-downloading it.
+
+## Skill versioning
+
+The `version` field on a skill entry is optional and carries a [semantic version](https://semver.org/) string identifying the artifact currently served at `url`. Clients may record this alongside the `digest` to give users a human-readable label for what is installed.
+
+### Versioned index paths
+
+Publishers that want clients to be able to fetch or pin a specific version should serve immutable index snapshots at a predictable versioned path alongside the mutable latest:
+
+```
+https://example.com/.well-known/agent-skills/index.json          ← latest (mutable)
+https://example.com/.well-known/agent-skills/v1.2.0/index.json   ← pinned snapshot (immutable)
+```
+
+A versioned index has the same shape as the canonical index. Skill `url` values are resolved per [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5) using the versioned index URL as the base URI, so relative URLs resolve correctly within the versioned path.
+
+```json /.well-known/agent-skills/v1.2.0/index.json
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "wrangler",
+      "version": "1.2.0",
+      "type": "archive",
+      "description": "Deploy and manage Cloudflare Workers projects.",
+      "url": "wrangler.tar.gz",
+      "digest": "sha256:a1b2c3d4..."
+    }
+  ]
+}
+```
+
+**Publishers must treat versioned index paths as immutable.** Once a versioned index is published, neither the index nor its referenced artifacts should be modified. This mirrors the convention enforced by package registries such as [npm](https://docs.npmjs.com/policies/unpublish) and [crates.io](https://crates.io/policies), where a published version cannot be overwritten.
+
+### Client lockfile pattern
+
+Clients may persist a lockfile recording the `version`, `digest`, and versioned index URL for each installed skill. On a subsequent install, the client fetches the versioned index directly — bypassing the mutable `index.json` — and re-verifies the artifact digest against the stored value.
+
+```json
+{
+  "wrangler": {
+    "version": "1.2.0",
+    "digest": "sha256:a1b2c3d4...",
+    "resolvedIndex": "https://example.com/.well-known/agent-skills/v1.2.0/index.json"
+  }
+}
+```
+
+The lockfile format is not standardised by this spec; clients may choose their own representation.
 
 ## HTTP requirements
 

--- a/docs/well-known-uri.mdx
+++ b/docs/well-known-uri.mdx
@@ -148,21 +148,21 @@ Publishers that want clients to be able to fetch or pin a specific version shoul
 
 ```
 https://example.com/.well-known/agent-skills/index.json          ← latest (mutable)
-https://example.com/.well-known/agent-skills/v1.2.0/index.json   ← pinned snapshot (immutable)
+https://example.com/.well-known/agent-skills/v0.1.1/index.json   ← pinned snapshot (immutable)
 ```
 
 A versioned index has the same shape as the canonical index. Skill `url` values are resolved per [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5) using the versioned index URL as the base URI, so relative URLs resolve correctly within the versioned path.
 
-```json /.well-known/agent-skills/v1.2.0/index.json
+```json /.well-known/agent-skills/v0.1.1/index.json
 {
   "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "skills": [
     {
-      "name": "wrangler",
-      "version": "1.2.0",
+      "name": "supabase",
+      "version": "0.1.1",
       "type": "archive",
-      "description": "Deploy and manage Cloudflare Workers projects.",
-      "url": "wrangler.tar.gz",
+      "description": "Use when doing ANY task involving Supabase.",
+      "url": "supabase.tar.gz",
       "digest": "sha256:a1b2c3d4..."
     }
   ]
@@ -177,10 +177,10 @@ Clients may persist a lockfile recording the `version`, `digest`, and versioned 
 
 ```json
 {
-  "wrangler": {
-    "version": "1.2.0",
+  "supabase": {
+    "version": "0.1.1",
     "digest": "sha256:a1b2c3d4...",
-    "resolvedIndex": "https://example.com/.well-known/agent-skills/v1.2.0/index.json"
+    "resolvedIndex": "https://supabase.com/.well-known/agent-skills/v0.1.1/index.json"
   }
 }
 ```

--- a/docs/well-known-uri.mdx
+++ b/docs/well-known-uri.mdx
@@ -169,7 +169,7 @@ A versioned index has the same shape as the canonical index. Skill `url` values 
 }
 ```
 
-**Publishers must treat versioned index paths as immutable.** Once a versioned index is published, neither the index nor its referenced artifacts should be modified. This mirrors the convention enforced by package registries such as [npm](https://docs.npmjs.com/policies/unpublish) and [crates.io](https://crates.io/policies), where a published version cannot be overwritten.
+**Publishers must treat versioned index paths as immutable.** Once a versioned index is published, neither the index nor its referenced artifacts should be modified. This mirrors the convention enforced by package registries such as [npm](https://docs.npmjs.com/policies/unpublish) and [Cargo](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-on-cratesio), where a published version cannot be overwritten.
 
 ### Client lockfile pattern
 


### PR DESCRIPTION
## Summary

The spec currently has no way for a client to request a specific version of a skill index, or to know which version of a skill it installed. The `digest` field gives integrity — you can detect that something changed — but not identity: there is no version label and no stable URL to go back to a known-good state.

This was raised in [#255](https://github.com/agentskills/agentskills/issues/255) by @petemounce:

> "For my org it's pretty important to trace the inputs to agents to debug the output, so knowing for sure which versions of particular skills were in play is key for that."

This PR also addresses [#46](https://github.com/agentskills/agentskills/issues/46), where @jonathanhefner noted that versioning belongs in the distribution mechanism rather than `SKILL.md`. PR #254 is that mechanism — this builds on top of it.

## What this PR adds

**An optional `version` field on each skill entry** — a semver string identifying what is currently served. Clients may record this alongside the `digest` to give users a human-readable label for what is installed.

**A versioned index path convention** — publishers that want to support version pinning serve immutable snapshots and a `versions.json` alongside the mutable latest:

```
/.well-known/agent-skills/index.json          ← latest (mutable)
/.well-known/agent-skills/versions.json       ← version list (mutable)
/.well-known/agent-skills/v0.1.1/index.json   ← pinned snapshot (immutable)
/.well-known/agent-skills/v0.2.0/index.json   ← pinned snapshot (immutable)
```

`versions.json` lets clients discover available versions without probing paths blindly — the same problem solved by [npm's packument](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md) and [Cargo's registry index](https://doc.rust-lang.org/cargo/reference/registry-index.html):

```json
{
  "latest": "0.2.0",
  "versions": ["0.1.0", "0.1.1", "0.2.0"]
}
```

Versioned indexes have the same shape as `index.json`. Skill `url` values resolve per RFC 3986 §5.2.2 using the versioned index URL as base URI, so relative URLs work correctly without changes to how artifacts are referenced.

**A client lockfile pattern** — clients record `version + digest + resolvedIndex` for each installed skill. On a locked fetch they go straight to the versioned index, bypass the mutable `index.json`, and re-verify the digest. Same pattern used by [npm](https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json) and [Cargo](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-on-cratesio).

**Publisher immutability expectation** — versioned index paths must be treated as immutable once published, mirroring the convention enforced by [npm](https://docs.npmjs.com/policies/unpublish) and [Cargo](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-on-cratesio). Unlike those registries there is no server-side enforcement mechanism here; this is a stated expectation on publishers, with the client-side digest check as a defence-in-depth layer.

## Real-world example

[Supabase](https://supabase.com) publishes skill tarballs as [GitHub release assets](https://github.com/supabase/agent-skills/releases) on every semver tag via Release Please, then fetches the latest release at build time and serves it from `supabase.com/.well-known/agent-skills/`. With this proposal, past releases already sitting on GitHub would serve as the immutable version history — no additional hosting infrastructure needed.