### PR TITLE
docs: fix name field character range to include digits

### DIFF
--- a/docs/specification.mdx
+++ b/docs/specification.mdx
@@ -59,7 +59,7 @@ metadata:
 
 The required `name` field:
 - Must be 1-64 characters
-- May only contain unicode lowercase alphanumeric characters (`a-z`) and hyphens (`-`)
+- May only contain unicode lowercase alphanumeric characters (`a-z`, `0-9`) and hyphens (`-`)
 - Must not start or end with a hyphen (`-`)
 - Must not contain consecutive hyphens (`--`)
 - Must match the parent directory name


### PR DESCRIPTION
The `name` field body text described valid characters as `(a-z)`, which only covers letters. The summary table directly above correctly states "Lowercase letters, numbers, and hyphens only."

This PR updates the range to `(a-z, 0-9)` so both descriptions are consistent.

**Before:**
```
May only contain unicode lowercase alphanumeric characters (`a-z`) and hyphens (`-`)
```

**After:**
```
May only contain unicode lowercase alphanumeric characters (`a-z`, `0-9`) and hyphens (`-`)
```

> This PR was written with assistance from Claude Code.