### PR TITLE
Add Implexa to client showcase

### DIFF
--- a/docs/images/logos/implexa/implexa-logo-dark.svg
+++ b/docs/images/logos/implexa/implexa-logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 120" width="480" height="120">
+  <g font-family="Inter, system-ui, sans-serif" font-weight="600" font-size="64" letter-spacing="-2">
+    <text x="40" y="80" fill="#FAFAF8">ı</text>
+    <circle cx="55" cy="34" r="7" fill="#34D399"/>
+    <text x="68" y="80" fill="#FAFAF8">mple</text>
+    <text x="220" y="80" fill="#FAFAF8">x</text>
+    <circle cx="241" cy="62" r="7" fill="#FF5722"/>
+    <text x="258" y="80" fill="#FAFAF8">a</text>
+  </g>
+</svg>

--- a/docs/images/logos/implexa/implexa-logo-dark.svg
+++ b/docs/images/logos/implexa/implexa-logo-dark.svg
@@ -1,10 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 120" width="480" height="120">
-  <g font-family="Inter, system-ui, sans-serif" font-weight="600" font-size="64" letter-spacing="-2">
-    <text x="40" y="80" fill="#FAFAF8">ı</text>
-    <circle cx="55" cy="34" r="7" fill="#34D399"/>
-    <text x="68" y="80" fill="#FAFAF8">mple</text>
-    <text x="220" y="80" fill="#FAFAF8">x</text>
-    <circle cx="241" cy="62" r="7" fill="#FF5722"/>
-    <text x="258" y="80" fill="#FAFAF8">a</text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 160" role="img" aria-label="Implexa">
+  <style>
+    .wm { font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif; font-weight: 700; font-size: 120px; letter-spacing: -4px; }
+  </style>
+  <!-- wordmark: dotless i (using ı) so we can place our own emerald tittle -->
+  <text x="40" y="125" class="wm" fill="#fafafa">ımplexa</text>
+  <!-- emerald tittle above the i -->
+  <circle cx="54" cy="40" r="11" fill="#34d399"/>
+  <!-- flame node centered on the x -->
+  <circle cx="350" cy="92" r="11" fill="#ff8a3c"/>
 </svg>

--- a/docs/images/logos/implexa/implexa-logo-light.svg
+++ b/docs/images/logos/implexa/implexa-logo-light.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 120" width="480" height="120">
+  <g font-family="Inter, system-ui, sans-serif" font-weight="600" font-size="64" letter-spacing="-2">
+    <text x="40" y="80" fill="#0A0805">ı</text>
+    <circle cx="55" cy="34" r="7" fill="#34D399"/>
+    <text x="68" y="80" fill="#0A0805">mple</text>
+    <text x="220" y="80" fill="#0A0805">x</text>
+    <circle cx="241" cy="62" r="7" fill="#FF5722"/>
+    <text x="258" y="80" fill="#0A0805">a</text>
+  </g>
+</svg>

--- a/docs/images/logos/implexa/implexa-logo-light.svg
+++ b/docs/images/logos/implexa/implexa-logo-light.svg
@@ -1,10 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 120" width="480" height="120">
-  <g font-family="Inter, system-ui, sans-serif" font-weight="600" font-size="64" letter-spacing="-2">
-    <text x="40" y="80" fill="#0A0805">ı</text>
-    <circle cx="55" cy="34" r="7" fill="#34D399"/>
-    <text x="68" y="80" fill="#0A0805">mple</text>
-    <text x="220" y="80" fill="#0A0805">x</text>
-    <circle cx="241" cy="62" r="7" fill="#FF5722"/>
-    <text x="258" y="80" fill="#0A0805">a</text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 160" role="img" aria-label="Implexa">
+  <style>
+    .wm { font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif; font-weight: 700; font-size: 120px; letter-spacing: -4px; }
+  </style>
+  <!-- wordmark: dotless i (using ı) so we can place our own emerald tittle -->
+  <text x="40" y="125" class="wm" fill="#0a0a0a">ımplexa</text>
+  <!-- emerald tittle above the i -->
+  <circle cx="54" cy="40" r="11" fill="#34d399"/>
+  <!-- flame node centered on the x -->
+  <circle cx="350" cy="92" r="11" fill="#ff8a3c"/>
 </svg>

--- a/docs/snippets/clients.jsx
+++ b/docs/snippets/clients.jsx
@@ -331,4 +331,13 @@ export const clients = [
     instructionsUrl: "https://fast-agent.ai/agents/skills/",
     sourceCodeUrl: "https://github.com/evalstate/fast-agent",
   },
+  {
+    name: "Implexa",
+    description: "Implexa records workflows as Agent Skills by demonstration. Run /implexa:record in Claude Code, do the workflow normally, and a post-demo interview locks the decision rationale into a SKILL.md you can run, share with your team, or fork from a public library — with outcome attribution showing which skills actually moved the needle.",
+    url: "https://implexa.ai",
+    lightSrc: "/images/logos/implexa/implexa-logo-light.svg",
+    darkSrc: "/images/logos/implexa/implexa-logo-dark.svg",
+    instructionsUrl: "https://github.com/Implexa-Inc/implexa-claude-plugin#readme",
+    sourceCodeUrl: "https://github.com/Implexa-Inc/implexa-claude-plugin",
+  },
 ];


### PR DESCRIPTION
**Product:** Implexa — [implexa.ai](https://implexa.ai)
**Skills implementation docs:** [github.com/Implexa-Inc/implexa-claude-plugin#readme](https://github.com/Implexa-Inc/implexa-claude-plugin#readme)
**Source code:** [github.com/Implexa-Inc/implexa-claude-plugin](https://github.com/Implexa-Inc/implexa-claude-plugin) (MIT-licensed plugin; hosted SaaS backend)

## What Implexa does

Implexa is a Claude Code plugin + hosted service that authors Agent Skills by **demonstration** rather than by description.

1. User runs `/implexa:record` in Claude Code
2. They do a real workflow — call tools, make decisions, produce output
3. A short post-demo interview (2–4 multiple-choice questions) extracts the *why* behind each decision, the output contract, and an outcome signal
4. Implexa emits a standard `SKILL.md` and writes it to `~/.claude/skills/{name}/`

The resulting skills are vanilla Agent Skills — frontmatter + Markdown body + optional bundled files — so they run in any agentskills.io-compatible client, not just Claude Code.

On top of the format we add three layers that fit cleanly alongside the spec rather than extending it:

- **Team sharing** — shareable links scoped private / org / universal-public, plus fork
- **Outcome attribution** — each skill declares a system-of-record event (CRM stage change, calendar accept, reply received) and we track which runs led to which outcomes
- **Public skill library** — community skills that users can fork into their own org

## Verification

- Publicly available today (launched May 2026, currently v0.6.0 of the plugin)
- Install: `curl -fsSL https://core.implexa.ai/install.sh | bash` — no waitlist, no signup gate, free tier
- Output `SKILL.md` files conform to the Agent Skills spec
- Happy to provide a screen-recording or live demo if useful

## Changes in this PR

1. `docs/images/logos/implexa/implexa-logo-light.svg` — light-mode wordmark (600×160, SVG, transparent bg)
2. `docs/images/logos/implexa/implexa-logo-dark.svg` — dark-mode wordmark (600×160, SVG, transparent bg)
3. `docs/snippets/clients.jsx` — new Implexa entry appended to the `clients` array

## AI disclosure

Per CONTRIBUTING.md: this PR description and the surrounding submission scaffolding were drafted with [Claude Code](https://claude.com/claude-code) (Claude Sonnet 4.5) assistance. The product description copy, logo SVG markup, and choice of which docs URL to point to were all reviewed by me (the founder) before submitting. AI helped structure the PR narrative and verify the contribution format matched existing entries in `clients.jsx`.

---

Happy to iterate on framing if the description copy is too long, or to swap `instructionsUrl` to a dedicated docs page (the GitHub README is currently our canonical Skills-implementation reference, but we have a `/claude-skills` docs page launching shortly). Thanks for maintaining this spec — it's the right level of openness for the ecosystem.