### PR TITLE
fix(skills-ref): read SKILL.md as UTF-8 (Windows cp1252 default crashes on em-dashes)

### DIFF
--- a/skills-ref/src/skills_ref/parser.py
+++ b/skills-ref/src/skills_ref/parser.py
@@ -86,7 +86,7 @@ def read_properties(skill_dir: Path) -> SkillProperties:
     if skill_md is None:
         raise ParseError(f"SKILL.md not found in {skill_dir}")
 
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     metadata, _ = parse_frontmatter(content)
 
     if "name" not in metadata:

--- a/skills-ref/src/skills_ref/validator.py
+++ b/skills-ref/src/skills_ref/validator.py
@@ -169,7 +169,7 @@ def validate(skill_dir: Path) -> list[str]:
         return ["Missing required file: SKILL.md"]
 
     try:
-        content = skill_md.read_text()
+        content = skill_md.read_text(encoding="utf-8")
         metadata, _ = parse_frontmatter(content)
     except ParseError as e:
         return [str(e)]

--- a/skills-ref/tests/test_parser.py
+++ b/skills-ref/tests/test_parser.py
@@ -26,6 +26,28 @@ Instructions here.
     assert "# My Skill" in body
 
 
+def test_read_properties_utf8(tmp_path):
+    """read_properties must read SKILL.md as UTF-8 regardless of platform default.
+
+    Regression: on Windows, Path.read_text() defaults to cp1252 and raises
+    UnicodeDecodeError on common UTF-8 punctuation (em-dash, smart quotes, etc.).
+    """
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: my-skill
+description: Extracts text — handles UTF-8 punctuation
+---
+# My Skill — café, naïve, résumé
+""",
+        encoding="utf-8",
+    )
+    props = read_properties(skill_dir)
+    assert props.name == "my-skill"
+    assert "—" in props.description  # em-dash survived the read
+
+
 def test_missing_frontmatter():
     content = "# No frontmatter here"
     with pytest.raises(ParseError, match="must start with YAML frontmatter"):

--- a/skills-ref/tests/test_validator.py
+++ b/skills-ref/tests/test_validator.py
@@ -16,6 +16,31 @@ description: A test skill
     assert errors == []
 
 
+def test_utf8_skill_md_unicode_content(tmp_path):
+    """SKILL.md must be read as UTF-8 regardless of platform default encoding.
+
+    Regression: on Windows, Path.read_text() defaults to cp1252 and raises
+    UnicodeDecodeError on common UTF-8 byte sequences (e.g. em-dash U+2014
+    encodes to 0xE2 0x80 0x94; smart quote U+201C encodes to 0xE2 0x80 0x9C).
+    """
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    # Write UTF-8 explicitly so the fixture is byte-identical across platforms.
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: my-skill
+description: Extracts text — handles UTF-8 punctuation like em-dashes, “smart quotes”, and ellipses…
+---
+# My Skill — Unicode body
+
+Body text with non-ASCII: café, naïve, façade, résumé.
+""",
+        encoding="utf-8",
+    )
+    errors = validate(skill_dir)
+    assert errors == []
+
+
 def test_nonexistent_path(tmp_path):
     errors = validate(tmp_path / "nonexistent")
     assert len(errors) == 1
@@ -171,7 +196,7 @@ name: 技能
 description: A skill with Chinese name
 ---
 Body
-""")
+""", encoding="utf-8")
     errors = validate(skill_dir)
     assert errors == []
 
@@ -185,7 +210,7 @@ name: мой-навык
 description: A skill with Russian name
 ---
 Body
-""")
+""", encoding="utf-8")
     errors = validate(skill_dir)
     assert errors == []
 
@@ -199,7 +224,7 @@ name: навык
 description: A skill with Russian lowercase name
 ---
 Body
-""")
+""", encoding="utf-8")
     errors = validate(skill_dir)
     assert errors == []
 
@@ -213,7 +238,7 @@ name: НАВЫК
 description: A skill with Russian uppercase name
 ---
 Body
-""")
+""", encoding="utf-8")
     errors = validate(skill_dir)
     assert any("lowercase" in e for e in errors)
 
@@ -285,6 +310,6 @@ name: {decomposed_name}
 description: A test skill
 ---
 Body
-""")
+""", encoding="utf-8")
     errors = validate(skill_dir)
     assert errors == [], f"Expected no errors, got: {errors}"


### PR DESCRIPTION
## Problem

On Windows, `Path.read_text()` defaults to the **cp1252** codec instead of UTF-8. Any `SKILL.md` containing common UTF-8 punctuation (em-dash `U+2014`, smart quotes, ellipsis, accented Latin chars) crashes both the validator and the parser:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 4781: character maps to <undefined>
```

Hit while validating [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) `obsidian-bases/SKILL.md` (contains em-dashes) on Windows 11 / Python 3.13.

**Reproducer:**
```bash
pip install skills-ref
echo '---
name: x
description: handles em-dashes —
---' > /tmp/x/SKILL.md
skills-ref validate /tmp/x   # crashes on Windows
```

## Fix

Pin UTF-8 explicitly on both `read_text()` calls in the production source. The agentskills.io spec doesn't currently mandate an encoding for `SKILL.md`, but UTF-8 is the de facto standard across npm, GitHub, and modern editors — the only encoding that consistently handles non-ASCII across the ecosystem.

**Production:**
| File | Line | Change |
|---|---|---|
| `skills-ref/src/skills_ref/parser.py` | 89 | `read_text()` → `read_text(encoding="utf-8")` |
| `skills-ref/src/skills_ref/validator.py` | 172 | same |

**Pre-existing test failures on Windows** — 5 i18n tests that use `write_text(...)` without encoding hit the same root cause on the write side (cp1252 can't *encode* Cyrillic / Chinese / combining accents). Fixed in the same PR for consistency:
- `test_i18n_chinese_name`
- `test_i18n_russian_name_with_hyphens`
- `test_i18n_russian_lowercase_valid`
- `test_i18n_russian_uppercase_rejected`
- `test_nfkc_normalization`

**New regression tests:**
- `test_parser.py::test_read_properties_utf8`
- `test_validator.py::test_utf8_skill_md_unicode_content`

## Verification

```
$ pytest tests/
============================= 42 passed in 0.38s ==============================
```

Before this PR: `37 passed, 5 failed` on Windows. After: `42 passed`.

Source diff: **+2 −2** (one line per file).
Test diff: **+47 −5** (5 fixture updates + 2 new regression tests).

## Why now

[kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) is the most popular community skills bundle (~700 ⭐). 4 of its 5 skills (`obsidian-cli`, `obsidian-markdown`, `defuddle`, `json-canvas`) validate fine; `obsidian-bases` doesn't, because its description has an em-dash. Most users hitting this won't connect the crash to character encoding — they'll just assume their skill is malformed and stop using `skills-ref validate`.