### PR TITLE
Add skill: heyneuron/flowhunt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Agent Skills are supported by a large number of AI tools and agentic clients —
 - **[Example Skills](https://github.com/anthropics/skills)** — See what's possible
 - **[Discord](https://discord.gg/MKPE9g8aUy)** — Share what you're building!
 
+## Community Skills
+
+Skills built by the community that are compatible with any Agent Skills-enabled agent (Claude Code, Codex CLI, OpenCode, and more).
+
+| Skill | Author | Description |
+|-------|--------|-------------|
+| [flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) | [heyneuron](https://github.com/heyneuron) | Automation discovery audit — walks through a 5-question workflow intake and audits Gmail, Calendar, Slack, and task trackers to identify automation opportunities |
+
+Install with `npx skills add heyneuron/flowhunt-skill`.
+
 ## Open development
 
 The Agent Skills format was originally developed by [Anthropic](https://www.anthropic.com/), released as an open standard, and has been adopted by a growing number of agent products. The standard is open to contributions from the broader ecosystem — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for how to get involved.


### PR DESCRIPTION
## Summary

Adds a **Community Skills** section to the README with an entry for [heyneuron/flowhunt-skill](https://github.com/heyneuron/flowhunt-skill).

**FlowHunt Skill** is an automation discovery audit skill. It walks through a 5-question workflow intake and audits Gmail, Calendar, Slack, and task trackers to identify automation opportunities.

Install:
```
npx skills add heyneuron/flowhunt-skill
```

The skill follows the Agent Skills specification and works with any compatible agent (Claude Code, Codex CLI, OpenCode, etc.).

> **AI Disclosure**: This PR was created with Claude Code assistance (automated branch + commit + PR creation). The skill entry and rationale were reviewed and approved by the skill author.